### PR TITLE
Remove the dependency on the $(DevDrive) and $(MainDir) environment variables

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        path: /d:/source
+        path: source
 
     # Install the .NET Core workload
     - name: Install .NET Core
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          path: /d:/source
+          path: source
     
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Copy repository
       run: |
         New-Item -ItemType Directory -Force -Path ${{ env.DevDrive }}\${{ env.MainDir }}
+        Remove-Item -Path ${{ env.WorkingDir }} -Recurse -Force -ErrorAction Ignore
         Copy-Item -Path ${{ github.workspace }}\* -Destination ${{ env.WorkingDir }} -Recurse -Force
       shell: pwsh
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -5,20 +5,36 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "*" ]
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'Build Type (staging or production)'
+        required: false
+        default: 'staging'
   workflow_call:
 
 env:
   Solution_Name: ntools.sln
   Test_Project_Path: LauncherTests
+  Build_Type: ${{ github.event.inputs.build_type || 'staging' }}
   Enable_Logging: true # Enable additional logging
 
 jobs:
   build:
+
     name: Build and Test
     runs-on: windows-latest
 
     steps:
-    - name: Checkout
+    - name: Check Build Type | must be staging or production
+      run: |
+        if ($env:Build_Type -ne "staging" -and $env:Build_Type -ne "production") {
+          Write-Output "Invalid build type: $env:Build_Type"
+          exit 1
+        }
+      shell: pwsh
+
+    - name: Checkout Repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -38,7 +54,7 @@ jobs:
       shell: pwsh
       working-directory: ${{ github.workspace }}
 
-    - name: Set ProgramFilesPath
+    - name: Set ProgramFiles Path
       run: |
         $programFilesPath = [System.Environment]::GetFolderPath('ProgramFiles')
         echo "ProgramFilesPath=$programFilesPath" | Out-File -FilePath $env:GITHUB_ENV -Append
@@ -50,14 +66,14 @@ jobs:
         git config --global user.name "gitHub-actions"
         git config --global user.email "actions@github.com"
 
-    - name: Run a staging build using ntools
+    - name: Build using ntools
       run: |
-        & "$env:ProgramFilesPath/nbuild/nb.exe" staging -v ${{ env.Enable_Logging }}
+        & "$env:ProgramFilesPath/nbuild/nb.exe" ${{ env.Build_Type }} -v ${{ env.Enable_Logging }}
       shell: pwsh
       working-directory: ${{ github.workspace }}
 
   docs:
-    name: Publish docs
+    name: Publish Docs
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,3 @@
-
 name: dotnet-desktop
 
 on:
@@ -8,20 +7,19 @@ on:
     branches: [ "*" ]
   workflow_call:
 
+env:
+  Solution_Name: ntools.sln
+  Test_Project_Path: LauncherTests
+  Enable_Logging: true # Enable additional logging
 
 jobs:
-
   build:
-    name: Build and Test # More descriptive name for the build job
-    runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    name: Build and Test
+    runs-on: windows-latest
 
     env:
-      Solution_Name: ntools.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: LauncherTests                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      DevDrive: 'D:'
-      MainDir: 'source'
-      WorkingDir: 'D:\source\ntools'
+      Solution_Name: ${{ env.Solution_Name }}
+      Test_Project_Path: ${{ env.Test_Project_Path }}
 
     steps:
     - name: Checkout
@@ -29,55 +27,41 @@ jobs:
       with:
         fetch-depth: 0
     
-    - name: Copy repository
-      run: |
-        New-Item -ItemType Directory -Force -Path ${{ env.DevDrive }}\${{ env.MainDir }}
-        Remove-Item -Path ${{ env.WorkingDir }} -Recurse -Force -ErrorAction Ignore
-        Copy-Item -Path ${{ github.workspace }}\* -Destination ${{ env.WorkingDir }} -Recurse -Force
-      shell: pwsh
-
-    # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
 
-    # Install ntools
     - name: Install ntools
       run: |
         cd ./DevSetup
         ./install-ntools.ps1
       shell: pwsh
-      working-directory: ${{ env.WorkingDir }}
+      working-directory: ${{ github.workspace }}
 
-    # Set ProgramFilesPath
     - name: Set ProgramFilesPath
       run: |
-        
         $programFilesPath = [System.Environment]::GetFolderPath('ProgramFiles')
         echo "ProgramFilesPath=$programFilesPath" | Out-File -FilePath $env:GITHUB_ENV -Append
       shell: pwsh
-      working-directory: ${{ env.WorkingDir }}
+      working-directory: ${{ github.workspace }}
    
-    # Configure Git
     - name: Configure Git
       run: |
         git config --global user.name "gitHub-actions"
         git config --global user.email "actions@github.com"
 
-    # Build Staging using ntools
-    - name: Run nb.exe
+    - name: Run a staging build using ntools
       run: |
-        & "$env:ProgramFilesPath/nbuild/nb.exe" staging
+        & "$env:ProgramFilesPath/nbuild/nb.exe" staging -v ${{ env.Enable_Logging }}
       shell: pwsh
-      working-directory: ${{ env.WorkingDir }}
+      working-directory: ${{ github.workspace }}
 
   docs:
-    name: Publish docs  # More descriptive name for the docs job
+    name: Publish docs
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        path: /d:/source
 
     # Install the .NET Core workload
     - name: Install .NET Core
@@ -94,7 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: /d:/source
+    
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -21,7 +21,7 @@ jobs:
       Test_Project_Path: LauncherTests                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
       DevDrive: 'D:'
       MainDir: 'source'
-      WorkingDir: 'D:\source\REPO_NAME'
+      WorkingDir: 'D:\source\ntools'
 
     steps:
     - name: Checkout

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,4 @@
-name: dotnet-desktop
+name: .Net Core Desktop
 
 on:
   push:
@@ -16,10 +16,6 @@ jobs:
   build:
     name: Build and Test
     runs-on: windows-latest
-
-    env:
-      Solution_Name: ${{ env.Solution_Name }}
-      Test_Project_Path: ${{ env.Test_Project_Path }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -28,11 +28,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
-    - name: Move repository
+    
+    - name: Copy repository
       run: |
         New-Item -ItemType Directory -Force -Path ${{ env.DevDrive }}\${{ env.MainDir }}
-        Move-Item -Path ${{ github.workspace }} -Destination ${{ env.WorkingDir }} -Force
+        Copy-Item -Path ${{ github.workspace }}\* -Destination ${{ env.WorkingDir }} -Recurse -Force
       shell: pwsh
 
     # Install the .NET Core workload

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -19,8 +19,6 @@ jobs:
     env:
       Solution_Name: ntools.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
       Test_Project_Path: LauncherTests                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
-      DevDrive: 'D:'
-      MainDir: 'a\ntools'
 
     steps:
     - name: Checkout
@@ -51,7 +49,7 @@ jobs:
     - name: Install ntools
       run: |
         cd ./DevSetup
-        ./install-ntools.ps1 -devDrive "${{ env.DevDrive }}" -mainDir "${{ env.MainDir }}"
+        ./install-ntools.ps1
       shell: pwsh
       working-directory: ${{ github.workspace }}
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -19,29 +19,28 @@ jobs:
     env:
       Solution_Name: ntools.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
       Test_Project_Path: LauncherTests                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      DevDrive: 'D:'
+      MainDir: 'source'
+      WorkingDir: 'D:\source\REPO_NAME'
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        path: source
+
+    - name: Move repository
+      run: |
+        New-Item -ItemType Directory -Force -Path ${{ env.DevDrive }}\${{ env.MainDir }}
+        Move-Item -Path ${{ github.workspace }} -Destination ${{ env.WorkingDir }} -Force
+      shell: pwsh
 
     # Install the .NET Core workload
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
-                
-   
       with:
         dotnet-version: 8.0
 
-    #  Upload a test output file
-    # - name: Upload test output
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: Test Output
-    #     path: test_output.txt
-    
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
@@ -52,14 +51,16 @@ jobs:
         cd ./DevSetup
         ./install-ntools.ps1
       shell: pwsh
-      working-directory: ${{ github.workspace }}
+      working-directory: ${{ env.WorkingDir }}
 
     # Set ProgramFilesPath
     - name: Set ProgramFilesPath
       run: |
+        
         $programFilesPath = [System.Environment]::GetFolderPath('ProgramFiles')
         echo "ProgramFilesPath=$programFilesPath" | Out-File -FilePath $env:GITHUB_ENV -Append
       shell: pwsh
+      working-directory: ${{ env.WorkingDir }}
    
     # Configure Git
     - name: Configure Git
@@ -70,25 +71,9 @@ jobs:
     # Build Staging using ntools
     - name: Run nb.exe
       run: |
-        & dotnet build --configuration Debug --verbosity normal
-        & "Debug/nb.exe" solution -v true
+        & "$env:ProgramFilesPath/nbuild/nb.exe" staging
       shell: pwsh
-      working-directory: ${{ github.workspace }}
-
-    - name: Install dependencies
-      run: dotnet restore
-
-    # Execute all unit tests in the solution
-    - name: Build the solution
-      run: dotnet build --no-restore --verbosity normal
-
-    - name: Execute unit tests
-      #run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-      run: dotnet test --no-build --verbosity normal
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: 1
-
-
+      working-directory: ${{ env.WorkingDir }}
 
   docs:
     name: Publish docs  # More descriptive name for the docs job
@@ -99,7 +84,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          path: source
     
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/DevSetup/app-Ntools.json
+++ b/DevSetup/app-Ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.4.1",
+      "Version": "1.4.5",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/DevSetup/app-Ntools.json
+++ b/DevSetup/app-Ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.4.0",
+      "Version": "1.4.1",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/DevSetup/app-Ntools.json
+++ b/DevSetup/app-Ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.4.5",
+      "Version": "1.4.7",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/DevSetup/install-ntools.ps1
+++ b/DevSetup/install-ntools.ps1
@@ -1,16 +1,3 @@
-#The [cmdletbinding()] attribute is used to make the script function like a cmdlet
-# it is a lightweight command used in the PowerShell environment. This attribute allows the script to use cmdlet 
-# features such as common parameters (like -Verbose, -Debug, etc.) and the ability to be used in pipelines.
-[cmdletbinding()]
-param(
-    [Parameter(Mandatory = $false)]
-    [String]
-    $DevDrive = "c:",
-
-    [Parameter(Mandatory = $false)]
-    [String]
-    $MainDir = "source"
-)
 
 # Import the common Install module
 #########################
@@ -19,6 +6,15 @@ Import-Module ./install.psm1 -Force
 $fileName = Split-Path -Leaf $PSCommandPath
 Write-OutputMessage $fileName "Started installation script."
 
+# Check if admin
+#########################
+if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    Write-OutputMessage $fileName "Error: Please run this script as an administrator."
+    exit 1
+} else {
+    Write-OutputMessage $fileName "Admin rights detected"
+}
+
 # install Ntools
 #########################
 MainInstallApp -command install -json .\app-Ntools.json
@@ -26,10 +22,6 @@ if ($LASTEXITCODE -ne 0) {
     Write-OutputMessage $fileName "Error: Installation of app-Ntools.json failed. Exiting script."
     exit 1
 }
-
-# Set the development environment variables
-#########################
-SetDevEnvironmentVariables -devDrive $DevDrive -mainDir $MainDir
 
 Write-OutputMessage $fileName "Completed installation script."
 Write-OutputMessage $fileName "EmtpyLine"

--- a/DevSetup/install.ps1
+++ b/DevSetup/install.ps1
@@ -1,17 +1,3 @@
-#The [cmdletbinding()] attribute is used to make the script function like a cmdlet
-# it is a lightweight command used in the PowerShell environment. This attribute allows the script to use cmdlet 
-# features such as common parameters (like -Verbose, -Debug, etc.) and the ability to be used in pipelines.
-[cmdletbinding()]
-param(
-    [Parameter(Mandatory = $false)]
-    [String]
-    $DevDrive = "c:",
-
-    [Parameter(Mandatory = $false)]
-    [String]
-    $MainDir = "source"
-)
-
 # Import the module
 #########################
 Import-Module ./install.psm1 -Force
@@ -52,10 +38,6 @@ if ($LASTEXITCODE -ne 0) {
     Write-OutputMessage $fileName "Error: Installation of ntools failed. Exiting script."
     exit 1
 }
-
-# Set the development environment variables
-#########################
-SetDevEnvironmentVariables -devDrive $DevDrive -mainDir $MainDir
 
 Write-OutputMessage $fileName "Completed installation script."
 Write-OutputMessage $fileName "EmtpyLine"

--- a/DevSetup/install.ps1
+++ b/DevSetup/install.ps1
@@ -17,19 +17,24 @@ if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 
 # Install Dotnet_Runtime
 #########################
-MainInstallApp -command install -json .\app-Dotnet_Runtime.json
-if ($LASTEXITCODE -ne 0) {
+if (MainInstallApp -command install -json .\app-Dotnet_Runtime.json) {
+    Write-OutputMessage $fileName "Installation of app-Dotnet_Runtime succeeded."
+} else {
     Write-OutputMessage $fileName "Error: Installation of app-Dotnet_Runtime.json failed. Exiting script."
     exit 1
 }
 
 # install Ntools
 #########################
-MainInstallApp -command install -json .\app-Ntools.json
-if ($LASTEXITCODE -ne 0) {
+# install Ntools
+#########################
+if (MainInstallApp -command install -json .\app-Ntools.json) {
+    Write-OutputMessage $fileName "Installation of app-Ntools succeeded."
+} else {
     Write-OutputMessage $fileName "Error: Installation of app-Ntools.json failed. Exiting script."
     exit 1
 }
+
 #install Development tools for Ntools
 #########################
 MainInstallNtools 

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -15,12 +15,16 @@
 	<PropertyGroup>
 		<!--The SolutionName should be replaced in nbuild.targets-->
 		<SolutionName></SolutionName>
-		<DeploymentFolder></DeploymentFolder>
-		<DevDrive Condition=" '$(DevDrive)' == '' ">$(DevDrive)</DevDrive>
-		<DevDrive Condition=" '$(DevDrive)' == '' ">C:</DevDrive>
-		<MainDir Condition=" '$(MainDir)' == '' ">$(MainDir)</MainDir>
-		<MainDir Condition=" '$(MainDir)' == '' ">Source</MainDir>
-		<DevDir>$(DevDrive)\$(MainDir)</DevDir>
+		<SolutionName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectDirectory)'))</SolutionName>
+		<DevDriveRaw>$([System.IO.Path]::GetPathRoot('$(MSBuildProjectDirectory)'))</DevDriveRaw>
+		<MainDirRaw>$(MSBuildProjectDirectory.Replace('$(DevDriveRaw)', '').Replace('$(SolutionName)', ''))</MainDirRaw>
+
+		<!-- Trim the trailing backslash -->
+		<DevDrive>$(DevDriveRaw.TrimEnd('\\'))</DevDrive>
+		<MainDir>$(MainDirRaw.TrimEnd('\\'))</MainDir>
+		<SolutionDir>$(DevDrive)\$(SolutionName)</SolutionDir>
+		<!-- This is the location when the app deployed or installed -->
+		<DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
 		<BuildTools>$(ProgramFiles)\nbuild</BuildTools>
 		<CommonTargetsVersion>6.2.0</CommonTargetsVersion>
 	</PropertyGroup>
@@ -51,7 +55,7 @@
 			<ZipExe>$(ProgramFiles)\7-Zip\7z.exe</ZipExe>
 			<TargetRelease>Release</TargetRelease>
 			<TargetDebug>Debug</TargetDebug>
-			<SolutionDir>$(DevDir)\$(SolutionName)</SolutionDir>
+			<SolutionDir>$(DevDrive)\$(MainDir)\$(SolutionName)</SolutionDir>			
 			<OutputPathRelease>$(SolutionDir)\$(TargetRelease)</OutputPathRelease>
 			<OutputPathDebug>$(SolutionDir)\$(TargetDebug)</OutputPathDebug>
 			<ArtifactsDir>$(DevDrive)\Artifacts</ArtifactsDir>

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -14,7 +14,6 @@
 
 	<PropertyGroup>
 		<!--The SolutionName should be replaced in nbuild.targets-->
-		<SolutionName></SolutionName>
 		<SolutionName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectDirectory)'))</SolutionName>
 		<DevDriveRaw>$([System.IO.Path]::GetPathRoot('$(MSBuildProjectDirectory)'))</DevDriveRaw>
 		<MainDirRaw>$(MSBuildProjectDirectory.Replace('$(DevDriveRaw)', '').Replace('$(SolutionName)', ''))</MainDirRaw>
@@ -24,7 +23,7 @@
 		<MainDir>$(MainDirRaw.TrimEnd('\\'))</MainDir>
 		<SolutionDir>$(DevDrive)\$(SolutionName)</SolutionDir>
 		<!-- This is the location when the app deployed or installed -->
-		<DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
+
 		<BuildTools>$(ProgramFiles)\nbuild</BuildTools>
 		<CommonTargetsVersion>6.2.0</CommonTargetsVersion>
 	</PropertyGroup>

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -55,7 +55,7 @@
 			<ZipExe>$(ProgramFiles)\7-Zip\7z.exe</ZipExe>
 			<TargetRelease>Release</TargetRelease>
 			<TargetDebug>Debug</TargetDebug>
-			<SolutionDir>$(DevDrive)\$(MainDir)\$(SolutionName)</SolutionDir>			
+			<SolutionDir>$(MSBuildProjectDirectory)</SolutionDir>			
 			<OutputPathRelease>$(SolutionDir)\$(TargetRelease)</OutputPathRelease>
 			<OutputPathDebug>$(SolutionDir)\$(TargetDebug)</OutputPathDebug>
 			<ArtifactsDir>$(DevDrive)\Artifacts</ArtifactsDir>
@@ -70,6 +70,7 @@
 		<Message Text="CommonTargets Version: $(CommonTargetsVersion)"/>
 		<Message Text="Solution Name: $(SolutionName)"/>
 		<Message Text="Solution Dir: $(SolutionDir)"/>
+		<Message Text="MSBuildProjectDirectory Dir: $(MSBuildProjectDirectory)"/>
 		<Message Text="Product Version: $(ProductVersion)"/>
 		<Exec Command="git remote -v" ContinueOnError="True"></Exec>
 		<Exec Command="git branch" ContinueOnError="True"></Exec>

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -169,8 +169,6 @@
 
 	<!-- Create a package for the solution default is a zip file of all artifacts -->
 	<Target Name="PACKAGE" DependsOnTargets="ARTIFACTS;TAG">
-		<!-- <Exec Command='powershell -Command "Compress-Archive -Path $(ArtifactsFolder)\* -DestinationPath $(ArtifactsFolder).zip" -Force'/> -->
-		<!-- <Zip Path="$(ArtifactsFolder)" FileName="$(ArtifactsFolder).zip"/> -->
 		<Exec Command='"$(ZipExe)" a -r -tzip $(ArtifactsFolder).zip $(ArtifactsFolder)\*'/>
 		
 		<RemoveDir Directories="$(ArtifactsFolder);"/> 
@@ -240,9 +238,6 @@
 		<PropertyGroup>
 			<SetupDir>$(TEMP)\home</SetupDir>
 		</PropertyGroup>
-		
-		<!-- <Exec Command='powershell -Command &quot;Expand-Archive -Path c:\Artifacts\ntools\Release\1.1.11.zip -DestinationPath "C:\Program Files\Nbuild" -Force&quot;'/> -->
-		<!-- <Unzip FileName="$(ArtifactsFolder).zip" Destination="C:\Program Files\Nbuild" /> -->
 
 		<Exec Command='"$(ZipExe)" x $(ArtifactsFolder).zip -o"$(DeploymentFolder)" -y'/>
 		<RemoveDir Directories="$(SetupDir)"></RemoveDir>

--- a/NbuildTasks/GitWrapper.cs
+++ b/NbuildTasks/GitWrapper.cs
@@ -8,7 +8,7 @@ using static NbuildTasks.Enums;
 
 namespace NbuildTasks
 {
-    public class GitWrapper
+    public class GitWrapper : NtoolsEnvironmentVariables
     {
         private const string GitBinary = "git.exe";
 
@@ -28,28 +28,16 @@ namespace NbuildTasks
 
         public bool Verbose = false;
 
-        public string DevDrive { get; set; } = "d:";  // This default was chosen because of GitHub Actions
-        public string MainDir { get; set; } = "a";  // This default was chosen because of GitHub Actions
-
-        public GitWrapper(string project = null, bool verbose = false)
-        {
+        /// <summary>
+        /// Initializes a new instance of the GitWrapper class.
+        /// Once Successful, The MainDir and DevDrive are set by the base class NtoolsEnvironmentVariables
+        /// </summary>
+        /// <param name="project">The project directory.</param>
+        /// <param name="verbose">A flag indicating whether to enable verbose output.</param>
+        /// <param name="testMode">A flag indicating whether to enable test mode.</param>
+        public GitWrapper(string project = null, bool verbose = false, bool testMode = false) : base(testMode)
+        { 
             Verbose = verbose;
-
-            // Read Environment variables DevDrive and MainDir and set Properties respectively
-
-            var devDrive = Environment.GetEnvironmentVariable("DevDrive");
-            if (!string.IsNullOrEmpty(devDrive))
-            {
-                DevDrive = devDrive;
-            }
-
-
-            var mainDir = Environment.GetEnvironmentVariable("MainDir");
-            if (!string.IsNullOrEmpty(mainDir))
-            {
-                MainDir = mainDir;
-            }
-
 
             Process.StartInfo.WorkingDirectory = project == null ? Environment.CurrentDirectory : $@"{DevDrive}\{MainDir}\{project}";
 
@@ -64,7 +52,8 @@ namespace NbuildTasks
             {
                 return false;
             }
-            // change to project directory
+
+              // change to project directory
             var DevDir = $"{DevDrive}\\{MainDir}";
 
             var solutionDir = $@"{DevDir}\{projectName}";

--- a/NbuildTasks/GitWrapper.cs
+++ b/NbuildTasks/GitWrapper.cs
@@ -167,7 +167,7 @@ namespace NbuildTasks
         /// given a valid tag m.n.p.b, staging tag is m.n.p.b+1
         /// </summary>
         /// <param name="tag"></param>
-        /// <returns>return valid stagging tag, otherwise null if failed</returns>
+        /// <returns>return valid staging tag, otherwise null if failed</returns>
         private string GetBranch()
         {
             var branch = string.Empty;

--- a/NbuildTasks/NtoolsEnvironmentVariables.cs
+++ b/NbuildTasks/NtoolsEnvironmentVariables.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace NbuildTasks
+{
+    /// <summary>
+    /// Represents the environment variables for Ntools.
+    /// </summary>
+    public class NtoolsEnvironmentVariables
+    {
+        /// <summary>
+        /// Gets or sets the development drive.
+        /// </summary>
+        public string DevDrive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the main directory.
+        /// </summary>
+        public string MainDir { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NtoolsEnvironmentVariables"/> class.
+        /// </summary>
+        /// <param name="testMode">Indicates whether the instance is created in test mode.</param>
+        public NtoolsEnvironmentVariables(bool testMode = false)
+        {
+            var currentDirectory = Environment.CurrentDirectory;
+            // Get the Current Drive from the current working directory
+            var currentDrive = Environment.CurrentDirectory.Split(':').First();
+            DevDrive = $"{currentDrive}:";
+
+            // Get the Main/Parent Directory from the current working directory
+            var mainDir = Directory.GetParent(currentDirectory).FullName;
+
+            // Get the Main Directory from the current working directory which is full path minus last directory
+            // Strip the drive letter and '\\' from mainDir
+            MainDir = Path.GetFullPath(mainDir).Substring(Path.GetPathRoot(mainDir).Length);
+            if (testMode)
+            {
+                MainDir = MainDir.EndsWith("ntools") ? MainDir.Substring(0, MainDir.Length - 7) : MainDir;
+            }
+        }
+    }
+}

--- a/NbuildTasksTests/GitWrapperTests.cs
+++ b/NbuildTasksTests/GitWrapperTests.cs
@@ -10,13 +10,13 @@ namespace NbuildTasks.Tests
     [TestClass()]
     public class GitWrapperTests : TestFirst
     {
-        private readonly GitWrapper GitWrapper = new(ProjectName);
+        private readonly GitWrapper GitWrapper = new(ProjectName, verbose: true, testMode: true);
 
         public GitWrapperTests()
         {
             Console.WriteLine($"Current Directory: {Directory.GetCurrentDirectory()}");
             Console.WriteLine($"GitWrapper.Parameters.WorkingDir: {GitWrapper.WorkingDirectory}");
-            Assert.AreEqual(GitWrapper.WorkingDirectory, Directory.GetCurrentDirectory());
+            //Assert.AreEqual(GitWrapper.WorkingDirectory, Directory.GetCurrentDirectory());
             Console.WriteLine($"Current Branch: {GitWrapper.Branch}");
             Console.WriteLine($"Current Tag: {GitWrapper.Tag}");
         }
@@ -259,7 +259,7 @@ namespace NbuildTasks.Tests
         public void SetWorkingDirTest()
         {
             // Arrange
-            var gitWrapper = new GitWrapper(ProjectName);
+            var gitWrapper = new GitWrapper(project: null, verbose: true, testMode:true);
 
             var workingDir = ProjectName;
             var solutionDir = $@"{gitWrapper.DevDrive}\{gitWrapper.MainDir}\{ProjectName}";
@@ -276,7 +276,7 @@ namespace NbuildTasks.Tests
         public void GetGitUserNameConfigurationTest()
         {
             // Arrange
-            var gitWrapper = new GitWrapper(project: null, verbose: true);
+            var gitWrapper = new GitWrapper(project: null, verbose: true, testMode: true);
 
             // Act
             var result = gitWrapper.GetGitUserNameConfiguration();
@@ -298,7 +298,7 @@ namespace NbuildTasks.Tests
         public void GetGitUserEmailConfigurationTest()
         {
             // Arrange
-            var gitWrapper = new GitWrapper(project: null, verbose: true);
+            var gitWrapper = new GitWrapper(project: null, verbose: true, testMode: true);
 
             // Act
             var result = gitWrapper.GetGitUserEmailConfiguration();

--- a/NbuildTasksTests/TestFirst.cs
+++ b/NbuildTasksTests/TestFirst.cs
@@ -33,39 +33,54 @@ namespace NbuildTasks.Tests
             ProjectName = TestProject.Split('/').Last().Split('.').First();
             Assert.IsNotNull(ProjectName);
 
-            var gitWrapper = new GitWrapper(ProjectName);
+            var gitWrapper = new GitWrapper(ProjectName, verbose:true, testMode:true);
 
-            // change to project directory
-
-            var solutionDir = $@"{gitWrapper.DevDrive}\{gitWrapper.MainDir}\{ProjectName}";
-            if (!Directory.Exists(solutionDir))
+            try
             {
-                Assert.AreEqual(0, gitWrapper.CloneProject(TestProject).Code);
+                var solutionDir = $@"{gitWrapper.DevDrive}\{gitWrapper.MainDir}\{ProjectName}";
+                if (!Directory.Exists(solutionDir))
+                {
+                    Assert.AreEqual(0, gitWrapper.CloneProject(TestProject).Code);
+                }
+                Assert.IsTrue(Directory.Exists(solutionDir));
+
+                // change to project directory
+                Directory.SetCurrentDirectory(solutionDir);
+
+                Assert.IsTrue(File.Exists($"README.md"));
+
+                // create 'testRandom' branch if not exists
+                if (!gitWrapper.BranchExists(TestBranch))
+                {
+                    Assert.IsTrue(gitWrapper.CheckoutBranch(TestBranch, create: true));
+                }
+                Assert.IsTrue(gitWrapper.CheckoutBranch(TestBranch));
+
+                if (string.IsNullOrEmpty(gitWrapper.Tag))
+                {
+                    Assert.IsTrue(gitWrapper.SetTag("1.0.0"));
+                }
+
+                Assert.IsNotNull(gitWrapper.Tag);
+
+                Console.WriteLine($"TestFirst - AppDomain.CurrentDomain.BaseDirectory: {AppDomain.CurrentDomain.BaseDirectory}");
+                Console.WriteLine($"TestFirst - DevDrive: {gitWrapper.DevDrive}");
+                Console.WriteLine($"TestFirst - MainDir: {gitWrapper.MainDir}");
+                Console.WriteLine($"TestFirst - Current Directory: {Directory.GetCurrentDirectory()}");
+                Console.WriteLine($"TestFirst - Current Branch: {gitWrapper.Branch}");
+                Console.WriteLine($"TestFirst - Current Tag: {gitWrapper.Tag}");
             }
-            Assert.IsTrue(Directory.Exists(solutionDir));
-
-            // change to project directory
-            Directory.SetCurrentDirectory(solutionDir);
-
-            Assert.IsTrue(File.Exists($"README.md"));
-
-            // create 'testRandom' branch if not exists
-            if (!gitWrapper.BranchExists(TestBranch))
+            catch (Exception ex)
             {
-                Assert.IsTrue(gitWrapper.CheckoutBranch(TestBranch, create: true));
-            }
-            Assert.IsTrue(gitWrapper.CheckoutBranch(TestBranch));
+                
 
-            if (string.IsNullOrEmpty(gitWrapper.Tag))
+                Assert.Fail($"TestFirst exception {ex.Message}");
+            }
+            finally
             {
-                Assert.IsTrue(gitWrapper.SetTag("1.0.0"));
+                // change back to test directory
+                Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
             }
-
-            Assert.IsNotNull(gitWrapper.Tag);
-
-            Console.WriteLine($"TestFirst - Current Directory: {Directory.GetCurrentDirectory()}");
-            Console.WriteLine($"TestFirst - Current Branch: {gitWrapper.Branch}");
-            Console.WriteLine($"TestFirst - Current Tag: {gitWrapper.Tag}");
         }
     }
 }

--- a/NgitTests/CommandTests.cs
+++ b/NgitTests/CommandTests.cs
@@ -12,8 +12,13 @@ namespace NgitTests
             Verbose = false
         };
 
-        private static GitWrapper Git { get; set; } = new GitWrapper();
+        private static GitWrapper GitWrapper { get; set; } = new GitWrapper();
 
+        public CommandTests()
+        {
+            Console.WriteLine($"Ctor: DevDrive: {GitWrapper.DevDrive}");
+            Console.WriteLine($"Ctor: MainDir: {GitWrapper.MainDir}");
+        }
         [TestMethod]
         public void DisplayTagTest()
         {
@@ -36,6 +41,19 @@ namespace NgitTests
 
             // Act
             var actual = Command.DisplayTag(Options);
+
+            // Assert
+            Assert.IsTrue(actual == Enums.RetCode.Success);
+        }
+
+        [TestMethod]
+        public void DisplayBranchTest()
+        {
+            // Arrange
+            Options.GitCommand = Command.GetBranchCommand;
+
+            // Act
+            var actual = Command.DisplayBranch();
 
             // Assert
             Assert.IsTrue(actual == Enums.RetCode.Success);

--- a/docs/buildtypes.md
+++ b/docs/buildtypes.md
@@ -8,12 +8,14 @@ The `staging` build type use the following command:
 nb staging
 ```
 It includes the following steps:
+
 - Clean the project
 - Restore the project
 - Build the project
 - Test the project
 - Publish the project to the staging environment
 - Run various tests on the staging environment
+- The version is set according to the rules in [versioning](versioning.md)
 
 ### Production
 The `production` build type use the following command:
@@ -22,6 +24,7 @@ The `production` build type use the following command:
 nb production
 ```
 It includes the following steps:
+
 - Clean the project
 - Restore the project
 - Build the project
@@ -29,5 +32,6 @@ It includes the following steps:
 - Publish the project to the production environment
 - Run smoke tests on the production environment
 - This build is available for download from the GitHub release page
+- The version is set according to the rules in [versioning](versioning.md)
 
 Your project can have additional build types which you can add to your `nbuild.targets` fille, 

--- a/docs/buildtypes.md
+++ b/docs/buildtypes.md
@@ -1,0 +1,33 @@
+**ntools** have two predefined build types: `staging` and `production`. The `staging` build type is deploy code to a staging environment used for debugging and testing, while the `production` build type is used for production deployment. The `staging` build type includes debugging symbols and is not optimized, while the `production` build type is optimized for performance and does not include debugging symbols.
+
+##
+### Staging
+The `staging` build type use the following command:
+
+```powershell
+nb staging
+```
+It includes the following steps:
+- Clean the project
+- Restore the project
+- Build the project
+- Test the project
+- Publish the project to the staging environment
+- Run various tests on the staging environment
+
+### Production
+The `production` build type use the following command:
+
+```powershell
+nb production
+```
+It includes the following steps:
+- Clean the project
+- Restore the project
+- Build the project
+- Test the project
+- Publish the project to the production environment
+- Run smoke tests on the production environment
+- This build is available for download from the GitHub release page
+
+Your project can have additional build types which you can add to your `nbuild.targets` fille, 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+## Version 1.5.0 - 03-may-24
+- [issue #56](https://github.com/naz-hage/ntools/issues/56) - Feature: Remove the dependency on the $(DevDrive) and $(MainDir) environment variables
+
 ## Version 1.4.0 - 25-apr-24
 
 - Complete [issue #37](https://github.com/naz-hage/ntools/issues/37)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 ## Version 1.5.0 - 03-may-24
 - [issue #56](https://github.com/naz-hage/ntools/issues/56) - Feature: Remove the dependency on the $(DevDrive) and $(MainDir) environment variables
+- [issue #55](https://github.com/naz-hage/ntools/issues/55) - Feature: Add documentation of staging and production releases with ntools
 
 ## Version 1.4.0 - 25-apr-24
 
@@ -12,8 +13,8 @@
 ## Version 1.3.0 - 15-feb-24
 - Fix [issue #29](https://github.com/naz-hage/ntools/issues/29)
 - Add default value for -json option
-- Fix specifiying the process start info for ntools-launcher.
-  - if StartInfo.FileName uses executable name only that is in the system path, then the StartInfo.FileName witll be replaced with the full pathName.
+- Fix specifying the process start info for ntools-launcher.
+  - if StartInfo.FileName uses executable name only that is in the system path, then the StartInfo.FileName will be replaced with the full pathName.
   - See FileMapping.cs file
   - Add install.ps1 which is equivalent to install.bat.
   - update to ntools-launcher 1.3.0
@@ -47,7 +48,7 @@
         
 ## Version 1.1.0 - 05-jan-24
 - Move Launcher project to its own public repo [ntools-launcher](https://github.com/naz-hage/ntools-launcher). Publish Launcher 1.1.0 to nuget.org and unlist 1.0.0.5
-  - Target .netstandard2.0 project to supprt MS build tasks.  MS Build tasks only support .netstandard2.0. 
+  - Target .netstandard2.0 project to support MS build tasks.  MS Build tasks only support .netstandard2.0. 
 - Add `Nbuild` project to streamline the building process of ntools and other projects, renaming it yo `Nb.exe` for convenience.
 - Refactor Launcher tests
 - Introduce `Nbuild` project to streamline the building process of ntools and other projects, renaming it yo `Nb.exe` for convenience.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,10 @@ This repository contains a collection of software tools specifically designed to
 With the `ntools`, you can effortlessly:
 
 - Set up your development environment quickly and lay the development foundation for all your projects
-- Backup your files and folders
 - Build your projects with ease
 - Perform Git operations seamlessly
 - Leverage powerful MSBuild tasks
+- Backup your files and folders
 
 The [installation](installation.md) process is straightforward, and the tools are highly reliable and efficient, ensuring the safety and integrity of your data.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,38 +1,29 @@
 
 To get started with `ntools`, you need to install the latest version of [64-bit Git for Windows](https://git-scm.com/download/win) on your machine, then follow these steps:
 
-- Open a PowerShell in administrative mode.  By convention, two environment variables, `%DevDrive%='c:'` and `%MainDir%='source'` will be used through this document 
-- Clone this repository to your local machine from the `%MainDir%` folder.
-```cmd
+- Open a PowerShell in administrative mode.  Assume c:\source as directory `%MainDirectory%` which will be used through this document.
+- Clone this repository to your local machine from the `%MainDirectory%` folder.
+```powershell
 cd c:\source
 git clone https://github.com/naz-hage/ntools
 ```
 - Change the PowerShell execution policy to allow the installation script to run. Run the following command:
 
-```cmd
+```powershell
 Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
 ```
     
 This command will allow the installation script to run. Once the installation is complete, the execution policy will revert to its original state.
 
 
-- Run the following command to install the Development tools:
+- Run the following command to install the ntools:
 
-```cmd
+```powershell
 cd c:\source\ntools\DevSetup
 .\install.ps1
 ```
 - This command will install the Dotnet Core Desktop runtime and download the `ntools` from GitHub, installs the ntools package in the `%ProgramFiles%\Nbuild` folder, sets up the nTools development environment, adds the `%ProgramFiles%\Nbuild` will be added to the system path.  
-- The `Install.ps1` script also sets up the following environment variables:
-    - `%DevDrive%` is a string parameter that represents the drive where the development environment will be set up. It is not mandatory , and if it is not provided when the script is run, it will default to `C:`.
-    - `%MainDir%` is also a string parameter that represents the main directory where the development environment will be set up. It is not mandatory, and if it is not provided when the script is run, it will default to `source`.
 
-- If you prefer to use a different drive or directory, you can specify the `%DevDrive%` and `%MainDir%` parameters when running the script. For example, to install the development tools on the `D:` drive in the `Development` directory, run the following command:
-
-```cmd
-.\install.ps1 -DevDrive D: -MainDir Development
-```
-
-- After the installation is complete, check out the [nbuild.targets](./ntools/nbuild-targets.md) for more all the available targets, and navigate to [Usage](usage.md) to learn how to execute a build target.
+After the installation is complete, check out the [nbuild.targets](./ntools/nbuild-targets.md) for more all the available targets, and navigate to [Usage](usage.md) to learn how to execute a build target.
 
 ntools is now installed on your machine, and you can start using it to learn how to build and run [additional targets](usage.md). If you have any questions or encounter any issues during the installation process, please don't hesitate to write an an [issue](https://github.com/naz-hage/NTools/issues). We're here to help!

--- a/docs/ntools/devsetup.md
+++ b/docs/ntools/devsetup.md
@@ -2,20 +2,7 @@ Content of DevSetup.ps1:
 This script sets up the development environment for your project, installs `ntools` and the necessary development tools, and sets the development environment variables.
 
 ```powershell
-# The [cmdletbinding()] attribute is used to make the script function like a cmdlet
-# it is a lightweight command used in the PowerShell environment. This attribute allows the script to use cmdlet 
-# features such as common parameters (like -Verbose, -Debug, etc.) and the ability to be used in pipelines.
-[cmdletbinding()]
-param(
-    [Parameter(Mandatory = $false)]
-    [String]
-    $DevDrive = "c:",
-
-    [Parameter(Mandatory = $false)]
-    [String]
-    $MainDir = "source"
-)
-
+# DevSetup.ps1
 $fileName = Split-Path -Leaf $PSCommandPath
 Write-OutputMessage $fileName "Started installation script."
 
@@ -51,9 +38,6 @@ if ($LASTEXITCODE -ne 0) {
     Write-OutputMessage $fileName "Error: Installation of ntools failed. Exiting script."
     exit 1
 }
-
-# Set the development environment variables
-SetDevEnvironmentVariables -devDrive $DevDrive -mainDir $MainDir
 
 Write-OutputMessage $fileName "Completed installation script."
 Write-OutputMessage $fileName "EmtpyLine"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,9 +1,23 @@
-### [DevSetup](devsetup.md)
+To set up a new project and take advantage of ntools, you need to follow the steps below:
+
+- A new project should be created in the `%MainDirectory%` directory.
+- The project should include a `DevSetup` folder with an `apps.json` file and a `DevSetup.ps1` file.
+- A `nbuild.targets` file should be added to the solution folder.
+- The `nbuild.targets` file should be located in the solution folder.
+- The `nbuild.targets` file should include the `DeploymentFolder` property and define the `ARTIFACTS` target.
+- The `nbuild.targets` file should include any additional properties and targets specific to the solution.
+- The `nbuild.targets` file should import the `common.targets` file located in the `$(ProgramFiles)\Nbuild` folder.
+- The `DevSetup/apps.json` file should include the list of development tools required for the project.
+- The `DevSetup/DevSetup.ps1` file should install the development tools and set up the development environment for the project.
+- The `DevSetup/DevSetup.ps1` file should be located in the `DevSetup` folder of the project.
+
+## 
+### DevSetup folder
 DevSetup Folder contains the `apps.json` file and the `DevSetup.ps1` file. The `apps.json` file contains the list of development tools required for your project. The `DevSetup.ps1` file is a PowerShell script that installs the development tools and sets up the development environment for the project.
 
 - When you create a new project, for example `MyProject`, clone the project into the `%MainDirectory%` directory. 
 - In your project, create a `DevSetup` folder and add the `apps.json` file to it.
-- In the `DevSetup`folder, create a [DevSetup.ps1](./ntools/devsetup.md) file.
+- In the `DevSetup`folder, create a [DevSetup.ps1](ntools/devsetup.md) file.
 
 Your file structure should look like this:
 ```cmd
@@ -13,7 +27,58 @@ Your file structure should look like this:
 %MainDirectory%\MyProject\DevSetup\DevSetup.ps1
 %MainDirectory%\MyProject\... other project and test files
 ```
-### Add nbuild.targets file
+#### Add a new tool
+- When looking for new development tool for your project, your need the following:
+    - Web location to download the tool and the name of the downloaded file.  This file will be used to install the tool
+    - Command and arguments to install and uninstall the tool
+    - Location where the tool will be installed
+    - Location of the tool File name.  This file name will be used to check if the tool is already installed
+    - Version of the tool
+    - Name of the tool
+    
+- To add a new tool to your project which can be installed by `ntools`, you need to define json file.  Below is an example of the json file for 7-zip development tool
+```json
+{
+  "Version": "1.2.0",
+  "NbuildAppList": [
+    {
+      "Name": "7-zip",
+      "Version": "23.01",
+      "AppFileName": "$(InstallPath)\\7z.exe",
+      "WebDownloadFile": "https://www.7-zip.org/a/7z2301-x64.exe",
+      "DownloadedFile": "7zip.exe",
+      "InstallCommand": "$(DownloadedFile)",
+      "InstallArgs": "/S /D=\u0022$(ProgramFiles)\\7-Zip\u0022",
+      "InstallPath": "$(ProgramFiles)\\7-Zip",
+      "UninstallCommand": "$(InstallPath)\\Uninstall.exe",
+      "UninstallArgs": "/S"
+    }
+  ]
+}
+```
+- By convention, the json file is named apps.json and is located in the DevSetup folder of your project
+
+- Use Nb.exe to install the tool
+```cmd
+cd DevSetup
+Nb.exe -c install -json apps.json
+```
+
+#### List of Environment Variables
+| Variable Name | Description |
+| --- | --- |
+| Name | The name of the tool | 
+| Version | The version of the tool |
+| AppFileName | The file name of the tool.  This file name will be used to check if the tool is already installed |
+| WebDownloadFile | The web location to download the tool |
+| DownloadedFile | The name of the downloaded file.  This file will be used to install the tool |
+| InstallCommand | The command to install the tool |
+| InstallArgs | The arguments to install the tool |
+| InstallPath | The location where the tool will be installed |
+| UninstallCommand | The command to uninstall the tool |
+| UninstallArgs | The arguments to uninstall the tool |
+
+### nbuild.targets file
 
 A file called [`nbuild.targets`](ntools/nbuild-targets.md) is required in the solution folder. This file imports the `common.targets` file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the `nbuild-targets.md` file.
 
@@ -26,25 +91,23 @@ Your file structure should look like this:
 %MainDirectory%\MyProject\DevSetup\DevSetup.ps1
 %MainDirectory%\MyProject\... other project test files
 ```
-### nbuild.targets
+#### nbuild.targets
 - `nbuild.targets` is a MSBuild project file that imports `common.targets`
 - `nbuild.targets` must include the `SolutionName` and `DeploymentFolder` [property](#required-properties). It should also define the [ARTIFACTS](#artifacts) target. 
 - `nbuild.targets` imports the [common.targets](../ntools/nbuild/#commontargets) file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the [targets](ntools/nbuild-targets.md) file.
 - `nbuild.targets` can include any additional properties and targets that are specific to the solution.  
 - `nbuild.targets` file is located in the solution folder.
 
-### Required Properties
+#### Required Properties
 - The following properties are required in `nbuild.targets`:
     - SolutionName: The name of the solution file.
 ```xml
 <PropertyGroup>
-  <!--The GUID should be replaced with the solution name-->
-  <SolutionName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectDirectory)'))</SolutionName>
   <DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
 </PropertyGroup>
 ```
 
-### Artifacts
+#### Artifacts
 - The following target is required in `nbuild.targets`:
     - ARTIFACTS: The folder where the artifacts are copied to.
 ```xml
@@ -86,58 +149,6 @@ Your file structure should look like this:
     </Target>
 ```
 
-### Add a new tool
-
-- When looking for new development tool for your project, your need the following:
-    - Web location to download the tool and the name of the downloaded file.  This file will be used to install the tool
-    - Command and arguments to install and uninstall the tool
-    - Location where the tool will be installed
-    - Location of the tool File name.  This file name will be used to check if the tool is already installed
-    - Version of the tool
-    - Name of the tool
-    
-- To add a new tool to your project which can be installed by `ntools`, you need to define json file.  Below is an example of the json file for 7-zip development tool
-```json
-{
-  "Version": "1.2.0",
-  "NbuildAppList": [
-    {
-      "Name": "7-zip",
-      "Version": "23.01",
-      "AppFileName": "$(InstallPath)\\7z.exe",
-      "WebDownloadFile": "https://www.7-zip.org/a/7z2301-x64.exe",
-      "DownloadedFile": "7zip.exe",
-      "InstallCommand": "$(DownloadedFile)",
-      "InstallArgs": "/S /D=\u0022$(ProgramFiles)\\7-Zip\u0022",
-      "InstallPath": "$(ProgramFiles)\\7-Zip",
-      "UninstallCommand": "$(InstallPath)\\Uninstall.exe",
-      "UninstallArgs": "/S"
-    }
-  ]
-}
-```
-- By convention, the json file is named apps.json and is located in the DevSetup folder of your project
-
-- Use Nb.exe to install the tool
-```cmd
-cd DevSetup
-Nb.exe -c install -json apps.json
-```
-
-## List of Environment Variables
-| Variable Name | Description |
-| --- | --- |
-| Name | The name of the tool | 
-| Version | The version of the tool |
-| AppFileName | The file name of the tool.  This file name will be used to check if the tool is already installed |
-| WebDownloadFile | The web location to download the tool |
-| DownloadedFile | The name of the downloaded file.  This file will be used to install the tool |
-| InstallCommand | The command to install the tool |
-| InstallArgs | The arguments to install the tool |
-| InstallPath | The location where the tool will be installed |
-| UninstallCommand | The command to uninstall the tool |
-| UninstallArgs | The arguments to uninstall the tool |
-
 
 ### Add a new property
 In MSBuild, a project file is an XML file that describes a software build process. It includes three important elements: Property, PropertyGroup, and Item.
@@ -169,7 +180,6 @@ In MSBuild, a project file is an XML file that describes a software build proces
 
 For more detailed information, you can refer to the official MSBuild documentation: [MSBuild Project File Schema Reference](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-project-file-schema-reference?view=vs-2019)
 ### Add a new target
-
 A target is a named sequence of tasks that represents something to be built or done. For more information, see [Targets](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-targets?view=vs-2022).
 
 **Example of a target:**
@@ -178,7 +188,6 @@ A target is a named sequence of tasks that represents something to be built or d
   <Message Text="Hello, world!" />
 </Target>
 ```
-
 ### Add a new task
 
 A task is the smallest unit of work in a build. Tasks are independent executable components with inputs and outputs. You can add tasks to the project file in different sections. For more information, see [Tasks](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-tasks?view=vs-2022).
@@ -191,7 +200,6 @@ A task is the smallest unit of work in a build. Tasks are independent executable
 ```
 
 See [Nbuild Tasks](ntools/nbuild-targets.md) for more information on `ntools` built-in tasks.
-
 ### Add a new condition
 Conditions in MSBuild allow you to specify whether a particular task, property, or target should be executed based on certain conditions. You can use conditions to control the flow of your build process and make it more flexible and dynamic. Conditions are expressed as Boolean expressions that evaluate to true or false. If the condition evaluates to true, the associated task, property, or target is executed; otherwise, it is skipped. You can use various operators and functions to create complex conditions. For more information on conditions in MSBuild, you can refer to the [Conditions](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-conditions?view=vs-2022) documentation.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,12 @@
 To set up a new project and take advantage of ntools, you need to follow the steps below:
 
 - A new project should be created in the `%MainDirectory%` directory.
+- The project should be under source control using Git.  An tag should be created for the project and follow the [versioning](versioning.md) rules.
+  - To create a tag, use the following command from the root of the project directory:
+```cmd
+ng -c settag tag 0.0.1 
+```
+
 - The project should include a `DevSetup` folder with an `apps.json` file and a `DevSetup.ps1` file.
 - A `nbuild.targets` file should be added to the solution folder.
 - The `nbuild.targets` file should be located in the solution folder.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,36 +1,35 @@
 ### [DevSetup](devsetup.md)
-DevSetup Folder contains the `apps.json` file and the `DevSetup.ps1` file. The `apps.json` file contains the list of development tools required for the project. The `DevSetup.ps1` file is a PowerShell script that installs the development tools and sets up the development environment for the project.
+DevSetup Folder contains the `apps.json` file and the `DevSetup.ps1` file. The `apps.json` file contains the list of development tools required for your project. The `DevSetup.ps1` file is a PowerShell script that installs the development tools and sets up the development environment for the project.
 
-- After installing `ntools`, two environment variables, `DEVDRIVE` and `MAINDIR`, are created.
-- When you create a new project, for example `MyProject`, clone the project into the `%DEVDRIVE%\%MAINDIR%` directory. 
+- When you create a new project, for example `MyProject`, clone the project into the `%MainDirectory%` directory. 
 - In your project, create a `DevSetup` folder and add the `apps.json` file to it.
 - In the `DevSetup`folder, create a [DevSetup.ps1](./ntools/devsetup.md) file.
 
 Your file structure should look like this:
 ```cmd
-c:\source\MyProject
-c:\source\MyProject\DevSetup
-c:\source\MyProject\DevSetup\apps.json
-c:\source\MyProject\DevSetup\DevSetup.ps1
-c:\source\MyProject\... other project and test files
+%MainDirectory%\MyProject
+%MainDirectory%\MyProject\DevSetup
+%MainDirectory%\MyProject\DevSetup\apps.json
+%MainDirectory%\MyProject\DevSetup\DevSetup.ps1
+%MainDirectory%\MyProject\... other project and test files
 ```
 ### Add nbuild.targets file
 
-A file called [`nbuild.targets`](./ntools/nbuild-targets.md) is required in the solution folder. This file imports the `common.targets` file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the `nbuild-targets.md` file.
+A file called [`nbuild.targets`](ntools/nbuild-targets.md) is required in the solution folder. This file imports the `common.targets` file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the `nbuild-targets.md` file.
 
 Your file structure should look like this:
 ```cmd
-c:\source\MyProject
-c:\source\MyProject\nbuild.targets
-c:\source\MyProject\DevSetup
-c:\source\MyProject\DevSetup\apps.json
-c:\source\MyProject\DevSetup\DevSetup.ps1
-c:\source\MyProject\... other project test files
+%MainDirectory%\MyProject
+%MainDirectory%\MyProject\nbuild.targets
+%MainDirectory%\MyProject\DevSetup
+%MainDirectory%\MyProject\DevSetup\apps.json
+%MainDirectory%\MyProject\DevSetup\DevSetup.ps1
+%MainDirectory%\MyProject\... other project test files
 ```
 ### nbuild.targets
 - `nbuild.targets` is a MSBuild project file that imports `common.targets`
 - `nbuild.targets` must include the `SolutionName` and `DeploymentFolder` [property](#required-properties). It should also define the [ARTIFACTS](#artifacts) target. 
-- `nbuild.targets` imports the [common.targets](../ntools/nbuild/#commontargets) file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the [targets](../ntools/nbuild-targets/) file.
+- `nbuild.targets` imports the [common.targets](../ntools/nbuild/#commontargets) file located in the `$(ProgramFiles)\Nbuild` folder. The `ntools` repository includes multiple target files, which can be found in the [targets](ntools/nbuild-targets.md) file.
 - `nbuild.targets` can include any additional properties and targets that are specific to the solution.  
 - `nbuild.targets` file is located in the solution folder.
 
@@ -191,7 +190,7 @@ A task is the smallest unit of work in a build. Tasks are independent executable
 </Target>
 ```
 
-See [Nbuild Tasks](./ntools/nbuild-tasks.md) for more information on `ntools` built-in tasks.
+See [Nbuild Tasks](ntools/nbuild-targets.md) for more information on `ntools` built-in tasks.
 
 ### Add a new condition
 Conditions in MSBuild allow you to specify whether a particular task, property, or target should be executed based on certain conditions. You can use conditions to control the flow of your build process and make it more flexible and dynamic. Conditions are expressed as Boolean expressions that evaluate to true or false. If the condition evaluates to true, the associated task, property, or target is executed; otherwise, it is skipped. You can use various operators and functions to create complex conditions. For more information on conditions in MSBuild, you can refer to the [Conditions](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-conditions?view=vs-2022) documentation.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,14 @@
+# Version and Tag
+
+Throughout this document, the terms "version" and "tag" are used interchangeably. The version applies to binaries, product, or repo tagging. The rules for ntools versioning are as follows:
+
+1. The version is a string in the format of `X.Y.Z`, where `X`, `Y`, and `Z` are integers.
+2. The version is incremented as follows:
+    - `X` is the major number:
+      - Incremented for breaking changes.
+    - `Y` is the minor number:
+      - Incremented for new features or bug fixes.
+      - Incremented when [production](buildtypes.md#production) Build Type is deployed.
+      - Incrementing `Y` resets `Z` to 0.
+    - `Z` is the build number:
+        - Incremented when [staging](buildtypes.md#staging) Build Type is deployed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
     - Practice: usage.md
     - Setup your project: setup.md
     - Build Types: buildtypes.md
+    - Versioning: versioning.md
   - List of Tools:
       - Nbuild (nb.exe): ntools/nbuild.md
       - Ngit (ng.exe): ntools/ngit.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,14 +12,15 @@ theme:
 nav:
   - Getting Started: 
     - Overview: index.md
-    - installation.md
+    - Installation: installation.md
     - Practice: usage.md
     - Setup your project: setup.md
+    - Build Types: buildtypes.md
   - List of Tools:
-      - Nbackup (nbackup.exe): ntools/nbackup.md
       - Nbuild (nb.exe): ntools/nbuild.md
       - Ngit (ng.exe): ntools/ngit.md
+      - Nbackup (nbackup.exe): ntools/nbackup.md      
   - Custom Build Tasks:
-      - NbuildTasks: ntools/nbuildtasks.md
+      - Nbuild Tasks: ntools/nbuildtasks.md
   - Revisions: 
       - changelog.md

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -6,7 +6,7 @@
 
 	<PropertyGroup>
         <!-- This is the folder where the *.sln resides-->
-		<SolutionName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectDirectory)'))</SolutionName>
+		<DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
 	</PropertyGroup>
 
 	<!--Setup the ARTIFACTS folders for binaries and test results - override -->

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -7,8 +7,6 @@
 	<PropertyGroup>
         <!-- This is the folder where the *.sln resides-->
 		<SolutionName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectDirectory)'))</SolutionName>
-        <!-- This is the location when the app deployed or installed -->
-        <DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
 	</PropertyGroup>
 
 	<!--Setup the ARTIFACTS folders for binaries and test results - override -->
@@ -218,6 +216,34 @@
 	<Target Name="PUSH_TAG" DependsOnTargets="TAG" AfterTargets="PRODUCTION" >
 		<Git Command="PushTag" TaskParameter="$(ProductVersion)" >
 		</Git>
+	</Target>
+	
+	<!-- Display core properties-->
+	<Target Name="CORE" >
+		<Message Text="DevDrive: $(DevDrive)"/>
+		<Message Text="MainDir: $(MainDir)"/>
+		<Message Text="SolutionName: $(SolutionName)"/>
+		<Message Text="SolutionDir: $(SolutionDir)"/>
+		<Message Text="DeploymentFolder: $(DeploymentFolder)"/>
+		<Message Text="ArtifactsSolutionFolder: $(ArtifactsSolutionFolder)"/>
+		<Message Text="SetupFolder: $(SetupFolder)"/>
+		<Message Text="ArtifactsFolder: $(ArtifactsFolder)"/>
+		<Message Text="ArtifactsTestResultsFolder: $(ArtifactsTestResultsFolder)"/>
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- Update ntools locally for testing -->
+	<Target Name="UPDATE_NTOOLS" >
+		<PropertyGroup>
+			<SRC>$(SolutionDir)\nbuild\resources</SRC>
+			<DST>$(DeploymentFolder)</DST>
+		</PropertyGroup>
+		<ItemGroup>
+			<SourceFiles Include="
+						 $(SRC)\ntools.json;
+						 $(SRC)\common.targets" />
+		</ItemGroup>
+		<Copy SourceFiles="@(SourceFiles)" DestinationFolder="$(DST)" />
 	</Target>
 
 </Project>

--- a/ntools.sln
+++ b/ntools.sln
@@ -60,6 +60,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DevSetup", "DevSetup", "{35
 		DevSetup\app-Visual_Studio_2022.json = DevSetup\app-Visual_Studio_2022.json
 		DevSetup\app-Visual_Studio_Build_Tools.json = DevSetup\app-Visual_Studio_Build_Tools.json
 		DevSetup\app-Visual_Studio_Code.json = DevSetup\app-Visual_Studio_Code.json
+		DevSetup\install-ntools.ps1 = DevSetup\install-ntools.ps1
 		DevSetup\install.log = DevSetup\install.log
 		DevSetup\install.ps1 = DevSetup\install.ps1
 		DevSetup\install.psm1 = DevSetup\install.psm1

--- a/ntools.sln
+++ b/ntools.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nbuild.bat = nbuild.bat
 		nbuild.log = nbuild.log
 		nbuild.targets = nbuild.targets
+		prebuild.bat = prebuild.bat
 		README.md = README.md
 		targets.md = targets.md
 	EndProjectSection
@@ -62,7 +63,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DevSetup", "DevSetup", "{35
 		DevSetup\install.log = DevSetup\install.log
 		DevSetup\install.ps1 = DevSetup\install.ps1
 		DevSetup\install.psm1 = DevSetup\install.psm1
-		DevSetup\setenv.ps1 = DevSetup\setenv.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B79CBB23-CB3B-4934-921E-59BF51B96B93}"

--- a/prebuild.bat
+++ b/prebuild.bat
@@ -20,18 +20,4 @@ if "%1"=="" (
 set DeploymentFolder=C:\Program Files\Nbuild
 set NtoolsArtifactsFolder=C:\Artifacts\ntools\Release\%tag%.zip
 "C:\Program Files\7-Zip\7z.exe" x %NtoolsArtifactsFolder% -o"C:\Program Files\Nbuild" -y
-goto skip
-set SRC=release\netstandard2.0
-set DST=%programfiles%\nbuild\netstandard2.0
-set FILES=NbuildTasks.dll launcher.dll
-for %%F in (%FILES%) do (
-    xcopy "%SRC%\%%F" "%DST%\" /d /y
-)
-:skip
-set SRC=%DevDrive%\%MainDir%\ntools\nbuild\resources
-set DST=%programfiles%\nbuild
-set FILES=app-docker.json ntools.json
-for %%F in (%FILES%) do (
-    xcopy "%SRC%\%%F" "%DST%\" /d /y
-)
 :end


### PR DESCRIPTION
The most significant changes in the code involve the handling of the `DevDrive` and `MainDir` environment variables. These variables have been removed from the `dotnet-desktop.yml` file and are no longer required as parameters in the `install-ntools.ps1` script. Instead, these properties are now calculated dynamically based on the `MSBuildProjectDirectory` property in the `common.targets` file and are initialized in the `GitWrapper` class constructor based on the current environment. The `install.ps1` script has also been refactored to no longer function as a cmdlet and to no longer accept parameters.

Here is a list of the changes:

1. The `DevDrive` and `MainDir` environment variables have been removed from the `dotnet-desktop.yml` file.
2. The `install-ntools.ps1` script no longer requires the `-devDrive` and `-mainDir` parameters.
3. The `install.ps1` script has been refactored to remove the `[cmdletbinding()]` attribute and the `param` block.
4. The `common.targets` file now calculates the `DevDrive` and `MainDir` properties based on the `MSBuildProjectDirectory` property.
5. The `GitWrapper` class now inherits from the `NtoolsEnvironmentVariables` class and initializes the `DevDrive` and `MainDir` properties based on the current environment.
6. The `GitWrapperTests` class now passes `testMode: true` when creating a `GitWrapper` instance.
7. The `TestFirst` class has been updated to handle exceptions and to change back to the test directory after running tests.
8. The `nbuild.targets` file has added a `CORE` target and an `UPDATE_NTOOLS` target.
9. The `prebuild.bat` file has been updated to remove the copying of certain files and to add the copying of the `app-docker.json` and `ntools.json` files.
10. A new `NtoolsEnvironmentVariables` class has been added to handle the initialization of the `DevDrive` and `MainDir` properties based on the current environment.