### PR TITLE
Update Ntools and Ngit project changes

### DIFF
--- a/DevSetup/app-Ntools.json
+++ b/DevSetup/app-Ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.4.7",
+      "Version": "1.5.0",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -15,7 +15,7 @@ public class Program
     private const string CmdList = "list";
     private const string CmdDownload = "download";
     private const string CmdHelp = "--help";
-    private const string NgitAssemblyExe = "ng.exe";
+    private const string NgitAssemblyExe = "ngit.exe";
     private static readonly int linesToDisplay = 10;
 
     static int Main(string[] args)

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -49,7 +49,7 @@
 	<!-- Common properties that will be used by all targets -->
 	<Target Name="PROPERTIES" DependsOnTargets="TAG">
 		<PropertyGroup>
-			<NbuildExe>"$(BuildTools)\ng.exe"</NbuildExe>
+			<NbuildExe>"$(BuildTools)\nb.exe"</NbuildExe>
 			<NugetExe>$(BuildTools)\nuget.exe</NugetExe>
 			<ZipExe>$(ProgramFiles)\7-Zip\7z.exe</ZipExe>
 			<TargetRelease>Release</TargetRelease>

--- a/NbuildTests/CommandTests.cs
+++ b/NbuildTests/CommandTests.cs
@@ -15,7 +15,7 @@ namespace NbuildTests
         private const string NbuildAssemblyName = "Nb.dll";
         private const string NbuildAppListJsonFile = "app-ntools.json";
         private const string LocalTest = "LOCAL_TEST";
-        private const string VersionToTest = "1.4.7";
+        private const string VersionToTest = "1.5.0";
         // Local test mode flag
         private bool? LocalTestMode;
 
@@ -97,7 +97,7 @@ namespace NbuildTests
                 ""NbuildAppList"": [
                 {
                 ""Name"": ""nbuild"",
-                ""Version"": ""1.4.7"",
+                ""Version"": ""1.5.0"",
                 ""AppFileName"": ""nb.exe"",
                 ""WebDownloadFile"": ""https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip"",
                 ""DownloadedFile"": ""$(Version).zip"",

--- a/Ngit/Ngit.csproj
+++ b/Ngit/Ngit.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
 	  <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	  <AssemblyName>Ng</AssemblyName>
+	  <AssemblyName>Ngit</AssemblyName>
   </PropertyGroup>
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+## Version 1.6.0 - 21-jun-24
+- [issue #62](https://github.com/naz-hage/ntools/issues/62) - Feature: Rename ng.exe to ngit.exe
+- 
 ## Version 1.5.0 - 03-may-24
 - [issue #56](https://github.com/naz-hage/ntools/issues/56) - Feature: Remove the dependency on the $(DevDrive) and $(MainDir) environment variables
 - [issue #55](https://github.com/naz-hage/ntools/issues/55) - Feature: Add documentation of staging and production releases with ntools
@@ -59,7 +62,7 @@
     - Git.PushTag
     - Git.DeleteTag
     - Git.GetBranch
-- Introduce `Ngit` project to provide a simplified and automated interface for git operations, renaming it to `Ng.exe` for convenience.
+- Introduce `Ngit` project to provide a simplified and automated interface for git operations.
     - Depends on DevDrive and MainDir environment variables.  Default values are used if they don't exist. DevDrive defaults to `C:` and MainDir defaults to `C:\source`.
 
 - Use DevDrive and MainDir from environment variables if they exist.  Otherwise, use default values.

--- a/docs/ntools/ngit.md
+++ b/docs/ntools/ngit.md
@@ -1,8 +1,8 @@
-`Ngit` (`ng.exe`) is simple wrapper for `Git` tool that perform simple commands such as get tag and set tag.
+`Ngit` is simple wrapper for `Git` tool that perform simple commands such as get tag and set tag.
 
 ### Usage
 ```batch
-Ng.exe [-c value] [-url value] [-tag value] [-buildtype value] [-v value]
+Ngit.exe [-c value] [-url value] [-tag value] [-buildtype value] [-v value]
 - c         : git Command, value= [tag | settag| autotag| setautotag| deletetag | branch | clone]
     tag         -> Get the current tag
     autotag     -> Set next tag based on the build type: STAGING vs.PRODUCTION

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
     - Versioning: versioning.md
   - List of Tools:
       - Nbuild (nb.exe): ntools/nbuild.md
-      - Ngit (ng.exe): ntools/ngit.md
+      - Ngit (ngit.exe): ntools/ngit.md
       - Nbackup (nbackup.exe): ntools/nbackup.md      
   - Custom Build Tasks:
       - Nbuild Tasks: ntools/nbuildtasks.md


### PR DESCRIPTION
- Upgraded Ntools version from 1.4.7 to 1.5.0 in `app-Ntools.json`.
- Renamed Ngit executable from `ng.exe` to `ngit.exe` across various files.
- Updated build executable reference from `ng.exe` to `nb.exe` in `common.targets`.
- Aligned test versions and Nbuild app version to 1.5.0 in `CommandTests.cs`.
- Modified assembly name to `Ngit` in `Ngit.csproj`.
- Enhanced documentation and changelog for Ngit executable renaming.
- Adjusted documentation navigation to reflect the new Ngit executable name in `mkdocs.yml`.