### PR TITLE
Add Terraform and Azure support to build process

### DIFF
--- a/DevSetup/Ntools.md
+++ b/DevSetup/Ntools.md
@@ -3,25 +3,23 @@ The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-envi
 
 - This table below list the latest dev tools that I use. I will try to keep this list up to date.
 
-| Link | Web Download | Version | Last Checked on |
-| --- | --- | --- | --- |
-| [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701?activetab=pivot:overviewtab) | --- | 1.11.2382.0 | Oct 1, 2023 |
-| [Visual Studio 2022 Community Edition – Download Latest Free Version](https://visualstudio.microsoft.com/vs/community/) | https://aka.ms/vs/17/release/vs_Community.exe |  17.8.3 | 08-jan-24 |
-| [Visual Studio Code](https://code.visualstudio.com/download) | https://aka.ms/win32-x64-system-stable |  1.91.1 | 24-jul-24 |
-| [Git](https://git-scm.com/downloads) | [Web Download](https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe) |  2.45.2 | 24-jul-24 |
-| [Node.js](https://nodejs.org/en/download/) | --- |  20.15.1 | 24-jul-24 |
-| [Download Postman Get Started for Free](https://www.postman.com/downloads/) | --- |  v10.18.7 | Oct 1, 2023 |
-| [Install Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/) | --- | 4.23 | Oct 1, 2023 |
-| [Download MongoDB Community Server](https://www.mongodb.com/try/download/community) | --- | 7.0.2 | Oct 1, 2023 |
-| [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install#install-wsl-command) |  --- | From Admin Powershell <br> `wsl --install -d Ubuntu-22.04` <br> [Activate the WSL integration in Docker Desktop settings](https://docs.docker.com/desktop/wsl/#turn-on-docker-desktop-wsl-2)| Oct 1, 2023 |
-| [Download .NET SDKs for Visual Studio](https://dotnet.microsoft.com/download/dotnet/7.0) | --- |  7.0.401 | Oct 1, 2023 |
-| [Install .NET SDK on Ubuntu 22.04](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2204#install-net) | --- |  From Ubuntu 22.04 <br> `sudo apt-get update && \ sudo apt-get install -y dotnet-sdk-7.0` <br> # Add .NET Core SDK tools <br> export PATH="$PATH:/home/naz/.dotnet/tools"| Oct 3, 2023 |
-| [Burp Suite](https://portswigger.net/burp/communitydownload) | --- |  2021.11.2 | Oct 1, 2023 |
-| [Draw.io](https://app.diagrams.net/) | --- |  --- | Oct 1, 2023 |
-| [Dotnet Runtime](https://dotnet.microsoft.com/en-us/) | [Web Download](https://dotnet.microsoft.com/en-us/download/dotnet) | 8.0.6 | 22-jun-24 |
-|  [PowerShell](https://docs.microsoft.com/en-us/powershell/) | [Web Download](https://github.com/PowerShell/PowerShell/releases/download/v$(Version)/PowerShell-$(Version)-win-x64.msi) | 7.4.3 | 22-jun-24 |
-| [Docker](https://www.docker.com/) | [Web Download](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe) | 4.31.1 | 22-jun-24 |
-|  [Nuget]() | [Web Download]() | 6.9.1.3 | 22-jun-24 |
-|  [LinSysInternalsk]() | [Web Download]() | 2.90.0 | 22-jun-24 |
-| [Python]() | [Web Download](https://www.python.org/ftp/python/$(Version)/python-$(Version)-amd64.exe) | 2.13.2 | 22-jun-24 |
-
+| Tool| Version | Last Checked on |
+| --- | --- | --- |
+| [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701?activetab=pivot:overviewtab) |  1.20.11781.0 | 28-jul-24 |
+| [Visual Studio 2022 Community Edition – Download Latest Free Version](https://visualstudio.microsoft.com/vs/community/) |  17.8.3 | 08-jan-24 |
+| [Visual Studio Code](https://code.visualstudio.com/download) |  1.91.1 | 24-jul-24 |
+| [Git](https://git-scm.com/downloads) |   2.45.2 | 24-jul-24 |
+| [Node.js](https://nodejs.org/en/download/) |   20.15.1 | 24-jul-24 |
+| [Download Postman Get Started for Free](https://www.postman.com/downloads/) |   v10.18.7 | Oct 1, 2023 |
+| [Install Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/) |  4.33 | 28-jul-24 |
+| [Download MongoDB Community Server](https://www.mongodb.com/try/download/community) |  7.0.12 | 28-jul-24 |
+| [Download .NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) |   8.0.7 | 28-jul-24 |
+| [Burp Suite](https://portswigger.net/burp/communitydownload) |   2021.11.2 | Oct 1, 2023 |
+| [Draw.io](https://app.diagrams.net/) |   --- | Oct 1, 2023 |
+| [Dotnet Runtime](https://dotnet.microsoft.com/en-us/) | 8.0.6 | 22-jun-24 |
+| [PowerShell](https://docs.microsoft.com/en-us/powershell/) | 7.4.3 | 22-jun-24 |
+| [Nuget]() |  6.9.1.3 | 22-jun-24 |
+| [SysInternals]() |  2.90.0 | 22-jun-24 |
+| [Python]() | 2.13.2 | 22-jun-24 |
+| [Install .NET SDK on Ubuntu 22.04](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2204#install-net) |   From Ubuntu 22.04 <br> `sudo apt-get update && \ sudo apt-get install -y dotnet-sdk-7.0` <br> # Add .NET Core SDK tools <br> export PATH="$PATH:/home/naz/.dotnet/tools"| Oct 3, 2023 |
+| [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install#install-wsl-command) |   From Admin Powershell <br> `wsl --install -d Ubuntu-22.04` <br> [Activate the WSL integration in Docker Desktop settings](https://docs.docker.com/desktop/wsl/#turn-on-docker-desktop-wsl-2)| Oct 1, 2023 |

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -311,7 +311,7 @@
 	</Target>
 
 	<!-- terraform apply -->
-	<Target Name="TF_APPLY" DependsOnTargets="TF_PLAN">
+	<Target Name="TF_APPLY" >
 		<Exec Command='terraform apply -auto-approve tfplan' WorkingDirectory="$(TerraformFolder)" />
 		<Message Text="==> DONE"/>
 	</Target>

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -26,6 +26,13 @@
 
 		<BuildTools>$(ProgramFiles)\nbuild</BuildTools>
 		<CommonTargetsVersion>6.2.0</CommonTargetsVersion>
+		<!-- Azure properties -->
+		<AzLocation>centralus</AzLocation>
+		<AzAcr>ShouldBeDefinedInNBuild.Targets</AzAcr>
+		
+		<!-- Terraform properties -->
+		<TerraformFolder>$(MSBuildProjectDirectory)\Terraform</TerraformFolder>
+
 	</PropertyGroup>
 	
 	<UsingTask TaskName="NbuildTasks.ColorMessage" AssemblyFile="$(BuildTools)\NbuildTasks.dll"/>
@@ -281,5 +288,38 @@
 	<!--Error handling placeholder -->
 	<Target Name="HandleError" >
 		<Message Text="An error occurred while reading the version file." Importance="high"/>
-	</Target>	
+	</Target>
+
+	<!-- Create a new terraform workspace `dev` and select it-->
+	<Target Name="TF_WORKSPACE_DEV">
+		<Exec Command="terraform workspace new dev" WorkingDirectory="$(SolutionDir)" IgnoreExitCode="true" />
+		<Exec Command="terraform workspace select dev" WorkingDirectory="$(SolutionDir)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- Init terraform -->
+	<Target Name="TF_INIT" >
+		<Exec Command='powershell -ExecutionPolicy Bypass -File ".\.set-secrets.ps1"' WorkingDirectory="$(UserProfile)" />
+		<Exec Command="terraform init" WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- terraform plan -->
+	<Target Name="TF_PLAN" DependsOnTargets="TF_INIT">
+		<Exec Command='terraform plan -out=tfplan' WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- terraform apply -->
+	<Target Name="TF_APPLY" DependsOnTargets="TF_PLAN">
+		<Exec Command='terraform apply -auto-approve tfplan' WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+
+	<!-- terraform destroy-->
+	<Target Name="TF_DESTROY">
+		<Exec Command="terraform destroy -auto-approve" WorkingDirectory="$(SolutionDir)" />
+		<Message Text="==> DONE"/>
+	</Target>
 </Project>

--- a/Nbuild/resources/terraform.targets
+++ b/Nbuild/resources/terraform.targets
@@ -1,0 +1,37 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!-- Create a new terraform workspace `dev` and select it-->
+	<Target Name="CREATE_TERRAFORM_WORKSPACE_DEV">
+		<Exec Command="terraform workspace new dev" WorkingDirectory="$(SolutionDir)" IgnoreExitCode="true" />
+		<Exec Command="terraform workspace select dev" WorkingDirectory="$(SolutionDir)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- Init terraform -->
+	<Target Name="TF_INIT" >
+		<Exec Command='powershell -ExecutionPolicy Bypass -File ".\.set-secrets.ps1"' WorkingDirectory="$(UserProfile)" />
+		<Exec Command="terraform init" WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- terraform plan -->
+	<Target Name="TF_PLAN" DependsOnTargets="TF_INIT">
+		<Exec Command='terraform plan -out=tfplan' WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- terraform apply -->
+	<Target Name="TF_APPLY" DependsOnTargets="TF_PLAN">
+		<Exec Command='terraform apply -auto-approve tfplan' WorkingDirectory="$(TerraformFolder)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+
+	<!-- terraform destroy-->
+	<Target Name="TF_DESTROY">
+		<Exec Command="terraform destroy -auto-approve" WorkingDirectory="$(SolutionDir)" />
+		<Message Text="==> DONE"/>
+	</Target>
+
+
+</Project>

--- a/NbuildTests/BuildStarterTests.cs
+++ b/NbuildTests/BuildStarterTests.cs
@@ -44,7 +44,12 @@ namespace Nbuild.Tests
                 "TEST_DEBUG",
                 "IS_ADMIN",
                 "SingleProject",
-                "HandleError"
+                "HandleError",
+                "TF_WORKSPACE_DEV",
+                "TF_INIT",
+                "TF_PLAN",
+                "TF_APPLY",
+                "TF_DESTROY"
             ];
 
             // Act

--- a/prebuild.bat
+++ b/prebuild.bat
@@ -6,7 +6,7 @@
 if "%1"=="" (
     rem deploy the latest version of ntools
     echo getting the latest version of ntools
-    ng -c tag | findstr /R "Tag [0-9]*\.[0-9]*\.[0-9]*" > temp.txt
+    ngit -c tag | findstr /R "Tag [0-9]*\.[0-9]*\.[0-9]*" > temp.txt
     rem the tag is in the 6th position
     for /f "tokens=6" %%A in (temp.txt) do set "tag=%%A"
     @REM echo latest_tag: %latest_tag%


### PR DESCRIPTION
This commit introduces significant enhancements to the build process by integrating Terraform for infrastructure as code management and adding Azure-specific configurations. Specifically, Azure location (`AzLocation`) and Azure Container Registry (`AzAcr`) properties have been added to the `common.targets` file, with `AzAcr` expected to be defined in `NBuild.Targets`. Additionally, Terraform-related properties, including a `TerraformFolder` pointing to a directory within the `MSBuildProjectDirectory`, have been introduced.

New MSBuild targets for Terraform operations (`TF_WORKSPACE_DEV`, `TF_INIT`, `TF_PLAN`, `TF_APPLY`, `TF_DESTROY`) have been added to both `common.targets` and a new `terraform.targets` file. These targets facilitate creating and selecting a Terraform workspace named `dev`, initializing Terraform, planning, applying, and destroying infrastructure as code.

Furthermore, the `BuildStarterTests.cs` file within the `Nbuild.Tests` namespace has been updated to include the newly added Terraform targets, ensuring that the tests cover the new functionality related to Terraform operations.

This modular approach in organizing Terraform-specific tasks into their own file, alongside the integration of Azure configurations, marks a significant step forward in streamlining and enhancing the build and deployment process.