### PR TITLE
Add and update PowerShell scripts for WAF and IP retrieval

### DIFF
--- a/devops-scripts/get-ip.ps1
+++ b/devops-scripts/get-ip.ps1
@@ -1,0 +1,35 @@
+# Description: This script retrieves the public IP address of the agent machine and sets it as a variable in the pipeline.
+# Usage: .\get-ip.ps1
+# in the pipeline, you can access the IP address using $(agentIp)
+# here is an example how to use it in the pipeline:
+# - task: PowerShell@2
+#   inputs:
+#     targetType: 'inline'
+#     script: |
+#       Write-Host "Agent IP: $(agentIp)"
+#       # do something with the agent IP
+#   displayName: 'Use Agent IP'
+#
+
+# Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell
+
+$maxAttempts = 5
+$count = 0
+$agentIp = $null
+
+while ($count -lt $maxAttempts -and $null -eq $agentIp) {
+  $count++
+  try {
+    $agentIp = (Invoke-RestMethod http://ipinfo.io/json).ip
+  } catch {
+    Write-Host "Failed to retrieve IP address. Retrying $count ..."
+    Start-Sleep -Seconds 5
+  }
+}
+
+if ($null -eq $agentIp) {
+  throw "IP Not Found"
+}
+
+Write-Output "IP Address: $agentIp"
+Write-Host "##vso[task.setvariable variable=agentIp]$agentIp"

--- a/devops-scripts/waf-frontdoor/add-waf-front-door-rule.ps1
+++ b/devops-scripts/waf-frontdoor/add-waf-front-door-rule.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$resourceGroupName,
+
+    [Parameter(Mandatory=$true)]
+    [string]$wafPolicyName,
+
+    [Parameter(Mandatory=$true)]
+    [string]$customRuleName,
+
+    [Parameter(Mandatory=$true)]
+    [string]$agentIp
+)
+
+Write-Host "Received parameters:"
+Write-Host "ResourceGroupName: $resourceGroupName"
+Write-Host "WafPolicyName: $wafPolicyName"
+Write-Host "CustomRuleName: $customRuleName"
+Write-Host "AgentIp: $agentIp"
+
+try {
+    # Create the custom rule
+    $result = az network front-door waf-policy rule create `
+        --action Allow `
+        --name $customRuleName `
+        --policy-name $wafPolicyName `
+        --resource-group $resourceGroupName `
+        --priority 20 `
+        --rule-type MatchRule `
+        --defer
+    if ($result) {
+        Write-Host "Custom rule '$customRuleName' added successfully."
+    } else {
+        Write-Error "Failed to add custom rule '$customRuleName'."
+        exit 1
+    }
+    # Add match condition to the custom rule
+    $result = az network front-door waf-policy rule match-condition add `
+        --match-variable SocketAddr `
+        --operator IPMatch `
+        --values "$agentIp" `
+        --negate false `
+        --name $customRuleName `
+        --resource-group $resourceGroupName `
+        --policy-name $wafPolicyName
+    if ($result) {
+        Write-Host "Match condition added to custom rule '$customRuleName' successfully."
+    } else {
+        Write-Error "Failed to add match condition to custom rule '$customRuleName'."
+        exit 1
+    }
+} catch {
+    Write-Error "An error occurred: $_"
+    exit 1
+}

--- a/devops-scripts/waf-frontdoor/delete-waf-front-door-rule.ps1
+++ b/devops-scripts/waf-frontdoor/delete-waf-front-door-rule.ps1
@@ -1,0 +1,51 @@
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory=$true)]
+  [string]$resourceGroupName,
+
+  [Parameter(Mandatory=$true)]
+  [string]$wafPolicyName,
+
+  [Parameter(Mandatory=$true)]
+  [string]$customRuleName
+)
+
+Write-Host "ResourceGroupName: $env:resourceGroupName"
+Write-Host "WafPolicyName: $env:wafPolicyName"
+Write-Host "CustomRuleName: $env:customRuleName"
+
+
+try {
+  # check for required parameters
+  if (-not $resourceGroupName) {
+    throw "Resource group name is required."
+  }
+  Write-Host "Resource group name: $resourceGroupName"
+
+  if (-not $wafPolicyName) {
+    throw "WAF policy name is required."
+  }
+  Write-Host "WAF policy name: $wafPolicyName"
+
+  if (-not $customRuleName) {
+    throw "Custom rule name is required."
+  }
+  Write-Host "Custom rule name: $customRuleName"
+
+  # remove a match-condition from the rule
+  $result = az network front-door waf-policy rule delete `
+    --name $customRuleName `
+    --policy-name $wafPolicyName `
+    --resource-group $resourceGroupName
+
+  if ($result) {
+    Write-Host "Custom rule '$customRuleName' deleted successfully."
+  }
+  else {
+    throw "Failed to delete custom rule '$customRuleName'."
+  }
+}
+catch {
+  Write-Error "An error occurred while deleting the custom rule: $_"
+  exit 1
+}


### PR DESCRIPTION
Updated `get-ip.ps1` to include description, usage instructions, and a reference link. The script now attempts to retrieve the public IP address up to 5 times with a 5-second delay between attempts, setting it as a pipeline variable upon success.

Added `add-waf-front-door-rule.ps1` to create a custom rule in an Azure Front Door WAF policy based on the agent IP.

Added `delete-waf-front-door-rule.ps1` to delete a custom rule from an Azure Front Door WAF policy, with error handling for required parameters.

Add WAF rule management scripts and update get-ip.ps1

Updated get-ip.ps1 to include description, usage instructions, and a reference link. The script now retries up to 5 times to retrieve the public IP address and sets it as a variable in the Azure DevOps pipeline.

Added add-waf-front-door-rule.ps1 to create a custom rule in an Azure Front Door WAF policy based on the agent's IP address.

Added delete-waf-front-door-rule.ps1 to delete a custom rule from an Azure Front Door WAF policy.