### PR TITLE
Add PATH management and update tool versions

### DIFF
--- a/.github/workflows/ntools.yml
+++ b/.github/workflows/ntools.yml
@@ -74,6 +74,19 @@ jobs:
         git config --global user.name "gitHub-actions"
         git config --global user.email "actions@github.com"
 
+        - name: Authenticate with GitHub
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.API_GITHUB_KEY }}@github.com/${{ github.repository }}
+          git fetch origin
+          git branch -r
+        shell: pwsh
+  
+        - name: Show changes
+          run: |
+            git status
+            git diff
+          shell: pwsh
+    
     - name: Run Build
       run: |
         & "$env:ProgramFilesPath/nbuild/nb.exe" CORE

--- a/.github/workflows/ntools.yml
+++ b/.github/workflows/ntools.yml
@@ -29,7 +29,7 @@ env:
   Test_Project_Path: LauncherTests
   build_type: ${{ github.event.inputs.build_type || 'stage' }}
   enable_logging: ${{ github.event.inputs.enable_logging || 'false' }}
-  dotnet_version: '9.0.2'
+  dotnet_version: '9.0.3'
 
 jobs:
   build:

--- a/.github/workflows/ntools.yml
+++ b/.github/workflows/ntools.yml
@@ -74,19 +74,19 @@ jobs:
         git config --global user.name "gitHub-actions"
         git config --global user.email "actions@github.com"
 
-        - name: Authenticate with GitHub
-        run: |
-          git remote set-url origin https://x-access-token:${{ secrets.API_GITHUB_KEY }}@github.com/${{ github.repository }}
-          git fetch origin
-          git branch -r
-        shell: pwsh
+    - name: Authenticate with GitHub
+      run: |
+        git remote set-url origin https://x-access-token:${{ secrets.API_GITHUB_KEY }}@github.com/${{ github.repository }}
+        git fetch origin
+        git branch -r
+      shell: pwsh
+
+    - name: Show changes
+      run: |
+        git status
+        git diff
+      shell: pwsh
   
-        - name: Show changes
-          run: |
-            git status
-            git diff
-          shell: pwsh
-    
     - name: Run Build
       run: |
         & "$env:ProgramFilesPath/nbuild/nb.exe" CORE

--- a/.github/workflows/ntools.yml
+++ b/.github/workflows/ntools.yml
@@ -29,6 +29,7 @@ env:
   Test_Project_Path: LauncherTests
   build_type: ${{ github.event.inputs.build_type || 'stage' }}
   enable_logging: ${{ github.event.inputs.enable_logging || 'false' }}
+  dotnet_version: '9.0.2'
 
 jobs:
   build:

--- a/.github/workflows/ntools.yml
+++ b/.github/workflows/ntools.yml
@@ -29,7 +29,6 @@ env:
   Test_Project_Path: LauncherTests
   build_type: ${{ github.event.inputs.build_type || 'stage' }}
   enable_logging: ${{ github.event.inputs.enable_logging || 'false' }}
-  dotnet_version: '9.0.3'
 
 jobs:
   build:

--- a/GitHubRelease/GitHubRelease.csproj
+++ b/GitHubRelease/GitHubRelease.csproj
@@ -7,6 +7,12 @@
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
+	<Version></Version>
+	<AssemblyVersion></AssemblyVersion>
+	<Authors>naz-hage</Authors>
+	<Company>naz-hage</Company>
+	<Product>Backup automation</Product>
+	<Copyright>2020-2025</Copyright>
   </PropertyGroup>
 	
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/GitHubReleaseTests/GitHubReleaseTests.csproj
+++ b/GitHubReleaseTests/GitHubReleaseTests.csproj
@@ -29,9 +29,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Nbuild/Cli.cs
+++ b/Nbuild/Cli.cs
@@ -10,6 +10,7 @@ public class Cli
         "\t uninstall \t -> Uninstalls apps specified in the -json option.\n" +
         "\t download \t -> Downloads apps specified in the -json option.\n" +
         "\t list \t\t -> Lists apps specified in the -json option.\n" +
+        "\t path \t\t -> Displays environment path in local machine.\n" +
         "\t ----\n" +
         "\t - By default, the -json option points to the ntools deployment folder: $(ProgramFiles)\\build\\ntools.json.\n" +
         "\t - The install, uninstall, and download commands require admin privileges to run.")]

--- a/Nbuild/Command.cs
+++ b/Nbuild/Command.cs
@@ -428,12 +428,16 @@ namespace Nbuild
             {
                 return false;
             }
+            var computedHashString = FileHashString(filePath);
+            return computedHashString.Equals(storedHash, StringComparison.InvariantCultureIgnoreCase);
+        }
 
+        private static string FileHashString(string? filePath)
+        {
             using var sha256 = SHA256.Create();
             using var stream = File.OpenRead(filePath!);
             var computedHash = sha256.ComputeHash(stream);
-            var computedHashString = BitConverter.ToString(computedHash).Replace("-", "").ToLowerInvariant();
-            return computedHashString.Equals(storedHash, StringComparison.InvariantCultureIgnoreCase);
+            return Convert.ToHexStringLower(computedHash);
         }
 
         private static ResultHelper SuccessfullInstall(NbuildApp nbuildApp, ResultHelper result)
@@ -451,6 +455,13 @@ namespace Nbuild
                     result.Code = 0;
                     return result;
                 }
+
+                // Print the stored hash of the app file name
+                if (!string.IsNullOrEmpty(nbuildApp.StoredHash))
+                {
+                    Colorizer.WriteLine($"[{ConsoleColor.Yellow}!Stored hash for {nbuildApp.AppFileName}: {FileHashString(nbuildApp.AppFileName)}]");
+                }
+
 
                 if (IsFileHashEqual(nbuildApp.AppFileName, nbuildApp.StoredHash))
                 {

--- a/Nbuild/Nbuild.csproj
+++ b/Nbuild/Nbuild.csproj
@@ -10,7 +10,7 @@
 	  <Authors>naz-hage</Authors>
 	  <Company>naz-hage</Company>
 	  <Product>Build automation</Product>
-	  <Copyright>2020-2024</Copyright>
+	  <Copyright>2020-2025</Copyright>
   </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Nbuild/NbuildApp.cs
+++ b/Nbuild/NbuildApp.cs
@@ -27,5 +27,6 @@ namespace Nbuild
         [Required(ErrorMessage = "UninstallArgs is required")]
         public string? UninstallArgs { get; set; }     // the arguments to pass to the uninstall command. can use $(Version) and $(InstallPath) to substitute the version number
         public string? StoredHash { get; set; }
+        public bool? AddToPath { get; set; } = false; // add the install path to the system path
     }
 }

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -14,6 +14,7 @@ public class Program
     private const string CmdUninstall = "uninstall";
     private const string CmdList = "list";
     private const string CmdDownload = "download";
+    private const string CmdPath = "path";
     private const string CmdHelp = "--help";
     private const string NgitAssemblyExe = "ngit.exe";
     private static readonly int linesToDisplay = 10;
@@ -65,6 +66,7 @@ public class Program
                         var d when d == CmdUninstall => Command.Uninstall(options.Json, options.Verbose),
                         var d when d == CmdList => Command.List(options.Json, options.Verbose),
                         var d when d == CmdDownload => Command.Download(options.Json, options.Verbose),
+                        var d when d == CmdPath => Command.DisplayPathSegments(),
                         _ => ResultHelper.Fail(-1, $"Invalid Command: '{options.Command}'"),
                     };
                 }

--- a/Nbuild/resources/ntools.json
+++ b/Nbuild/resources/ntools.json
@@ -64,7 +64,7 @@
     },
     {
       "Name": "Visual Studio Code",
-      "Version": "1.98.0",
+      "Version": "1.98.2",
       "AppFileName": "$(InstallPath)\\Code.exe",
       "WebDownloadFile": "https://aka.ms/win32-x64-system-stable",
       "DownloadedFile": "VSCodeSetup-x64-$(Version).exe",

--- a/NbuildTasks/NbuildTasks.csproj
+++ b/NbuildTasks/NbuildTasks.csproj
@@ -7,7 +7,7 @@
 	  <Authors>naz-hage</Authors>
 	  <Company>naz-hage</Company>
 	  <Product>Build automation</Product>
-	  <Copyright>2020-2024</Copyright>
+	  <Copyright>2020-2025</Copyright>
   </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />	  
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />	  
     <PackageReference Include="ntools-launcher" Version="1.6.0" />
   </ItemGroup>
 

--- a/NbuildTasksTests/NbuildTasksTests.csproj
+++ b/NbuildTasksTests/NbuildTasksTests.csproj
@@ -22,9 +22,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NbuildTests/NbuildTests.csproj
+++ b/NbuildTests/NbuildTests.csproj
@@ -25,9 +25,9 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />	  
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />	  
     <PackageReference Include="coverlet.collector" Version="6.0.4">
 		
       <PrivateAssets>all</PrivateAssets>

--- a/Ngit/Ngit.csproj
+++ b/Ngit/Ngit.csproj
@@ -10,7 +10,7 @@
 	  <Authors>naz-hage</Authors>
 	  <Company>blue-man</Company>
 	  <Product>Git Wrapper</Product>
-	  <Copyright>2020-2024</Copyright>
+	  <Copyright>2020-2025</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/NgitTests/ngitTests.csproj
+++ b/NgitTests/ngitTests.csproj
@@ -23,9 +23,9 @@
 	</PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />	  
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />	  
     <PackageReference Include="coverlet.collector" Version="6.0.4">
 		
       <PrivateAssets>all</PrivateAssets>

--- a/dev-setup/apps.json
+++ b/dev-setup/apps.json
@@ -236,7 +236,7 @@
     },
     {
       "Name": "Visual Studio Code",
-      "Version": "1.98.0",
+      "Version": "1.98.2",
       "AppFileName": "$(InstallPath)\\Code.exe",
       "WebDownloadFile": "https://aka.ms/win32-x64-system-stable",
       "DownloadedFile": "VSCodeSetup-x64-$(Version).exe",

--- a/dev-setup/apps.json
+++ b/dev-setup/apps.json
@@ -15,27 +15,30 @@
     },
     {
       "Name": "Argo CD",
-      "Version": "2.9.3",
+      "Version": "2.14.5",
       "AppFileName": "$(InstallPath)\\argocd.exe",
       "WebDownloadFile": "https://github.com/argoproj/argo-cd/releases/download/v$(Version)/argocd-windows-amd64.exe",
       "DownloadedFile": "argocd.exe",
       "InstallCommand": "xcopy.exe",
       "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
-      "InstallPath": "$(ProgramFiles)\\ArgoCD\\",
+      "InstallPath": "$(ProgramFiles)\\ArgoCD",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\argocd.exe' -Force; if ((Get-ChildItem -Path '$(InstallPath)' -Force).Count -eq 0) { Remove-Item -Path '$(InstallPath)' -Force }; Write-Output 'ArgoCD CLI uninstalled.'\""
+      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+      "StoredHash": "D93E14EEBE6FD0B8F6677D95617982B7C9D73617D3F714C36D19C087C0E7A9FB",
+      "AddToPath": true
     },
     {
       "Name": "AzureCLI",
-      "Version": "2.63.0",
-      "AppFileName": "$(InstallPath)\\az.exe",
-      "WebDownloadFile": "https://aka.ms/installazurecliwindows",
+      "Version": "2.70.0",
+      "AppFileName": "$(InstallPath)\\az.cmd",
+      "WebDownloadFile": "https://azcliprod.blob.core.windows.net/msi/azure-cli-$(Version)-x64.msi",
       "DownloadedFile": "AzureCLI-$(Version)-win-x64.msi",
       "InstallCommand": "msiexec.exe",
       "InstallArgs": "/i AzureCLI-$(Version)-win-x64.msi /quiet",
-      "InstallPath": "$(ProgramFiles)\\AzureCLI",
+      "InstallPath": "$(ProgramFiles)\\Microsoft SDKs\\Azure\\CLI2\\wbin",
       "UninstallCommand": "msiexec.exe",
-      "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet"
+      "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet",
+      "StoredHash": "F24C501B242614AFA989ACF22719C816BE87E7AC1FF8FF84C5FA200751F30FE2"
     },
     {
       "Name": "AzurePowershell",
@@ -62,10 +65,22 @@
       "UninstallArgs": "-Command \"\u0026 {Start-Process -FilePath '$(InstallPath)\\Docker Desktop Installer.exe' -ArgumentList 'uninstall --quiet' -NoNewWindow -Wait; while ((Get-Process 'Docker Desktop Installer' -ErrorAction SilentlyContinue) -or (Get-Process 'Docker' -ErrorAction SilentlyContinue)) { Start-Sleep -Seconds 5 }}\""
     },
     {
-      "Name": "Dotnet Runtime",
-      "Version": "8.0.1",
+      "Name": "Dotnet Desktop Runtime",
+      "Version": "9.0.2",
       "AppFileName": "$(InstallPath)\\dotnet.exe",
-      "WebDownloadFile": "https://download.visualstudio.microsoft.com/download/pr/f18288f6-1732-415b-b577-7fb46510479a/a98239f751a7aed31bc4aa12f348a9bf/windowsdesktop-runtime-$(Version)-win-x64.exe",
+      "WebDownloadFile": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/$(Version)/windowsdesktop-runtime-$(Version)-win-x64.exe",
+      "DownloadedFile": "dotnet_installer.exe",
+      "InstallCommand": "dotnet_installer.exe",
+      "InstallArgs": "/quiet /norestart\"",
+      "InstallPath": "$(ProgramFiles)\\dotnet",
+      "UninstallCommand": "dotnet_installer.exe",
+      "UninstallArgs": "/uninstall /quiet /norestart"
+    },
+    {
+      "Name": "Dotnet Runtime",
+      "Version": "9.0.2",
+      "AppFileName": "$(InstallPath)\\dotnet.exe",
+      "WebDownloadFile": "https://builds.dotnet.microsoft.com/dotnet/Runtime/$(Version)/dotnet-runtime-$(Version)-win-x64.exe",
       "DownloadedFile": "dotnet_installer.exe",
       "InstallCommand": "dotnet_installer.exe",
       "InstallArgs": "/quiet /norestart\"",
@@ -75,7 +90,7 @@
     },
     {
       "Name": "Git for Windows",
-      "Version": "2.47.1",
+      "Version": "2.49.0",
       "AppFileName": "$(InstallPath)\\bin\\git.exe",
       "WebDownloadFile": "https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe",
       "DownloadedFile": "Git-$(Version)-64-bit.exe",
@@ -100,16 +115,17 @@
     },
     {
       "Name": "kubectl",
-      "Version": "1.32.2",
+      "Version": "1.32.3",
       "AppFileName": "$(InstallPath)\\kubectl.exe",
       "WebDownloadFile": "https://dl.k8s.io/release/v$(Version)/bin/windows/amd64/kubectl.exe",
       "DownloadedFile": "kubectl.exe",
       "InstallCommand": "xcopy.exe",
       "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
-      "InstallPath": "$(ProgramFiles)\\kubectl\\",
+      "InstallPath": "$(ProgramFiles)\\kubectl",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"Remove-Item -Path '$(ProgramFiles)\\kubectl\\kubectl.exe' -Force; [Environment]::SetEnvironmentVariable('Path', $env:Path -replace ';$(ProgramFiles)\\kubectl', '', [EnvironmentVariableTarget]::Machine); Write-Output 'kubectl uninstalled.'\"",
-      "StoredHash": "CF51A1C6BF3B6BA6A5B549D1DEBF8AA6AFB00C4C5A3D5D4BB1072F54CBE4390F"
+      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+      "StoredHash": "3fd1576a902ecf713f7d6390ae01799e370883e0341177ee09dbdc362db953e3",
+      "AddToPath": true
     },
     {
       "Name": "minikube",
@@ -119,10 +135,11 @@
       "DownloadedFile": "minikube-installer.exe",
       "InstallCommand": "powershell.exe",
       "InstallArgs": "-Command \"Start-Process -FilePath '$(DownloadedFile)' -ArgumentList '/S' -Wait; ",
-      "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube\\",
+      "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"$uninstaller = '$(InstallPath)\\Uninstall Minikube.exe'; if (Test-Path $uninstaller) { Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait; Write-Output 'Minikube uninstalled.' } else { Write-Output 'Minikube uninstaller not found.' }\"",
-      "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA"
+      "UninstallArgs": "-Command \"Start-Process -FilePath '$(InstallPath)\\Uninstall.exe' -ArgumentList '/S' -Wait;\"",
+      "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA",
+      "AddToPath": true
     },
     {
       "Name": "MongoDB",
@@ -138,7 +155,7 @@
     },
     {
       "Name": "Ntools",
-      "Version": "1.9.0",
+      "Version": "1.10.1",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",
@@ -146,7 +163,8 @@
       "InstallArgs": "-Command Expand-Archive -Path $(Version).zip -DestinationPath '$(InstallPath)' -Force",
       "InstallPath": "$(ProgramFiles)\\Nbuild",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force"
+      "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
+      "AddToPath": true
     },
     {
       "Name": "Nuget",
@@ -198,20 +216,21 @@
     },
     {
       "Name": "Terraform",
-      "Version": "1.9.5",
+      "Version": "1.11.1",
       "AppFileName": "$(InstallPath)\\terraform.exe",
       "WebDownloadFile": "https://releases.hashicorp.com/terraform/$(Version)/terraform_$(Version)_windows_amd64.zip",
       "DownloadedFile": "terraform_$(Version)_windows_amd64.zip",
       "InstallCommand": "powershell.exe",
       "InstallArgs": "-Command \"Expand-Archive -Path '$(DownloadedFile)' -DestinationPath '$(InstallPath)'\" -Force",
-      "InstallPath": "$(ProgramFiles)\\Terraform\\",
+      "InstallPath": "$(ProgramFiles)\\Terraform",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\terraform.exe' -Force\"",
-      "StoredHash": "9A9B81018E40DADBC1EDA63C95C601878A5CA0CD4EF52A87DE0DE940F88E93C9"
+      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C",
+      "AddToPath": true
     },
     {
       "Name": "terraform lint",
-      "Version": "0.53.0",
+      "Version": "0.55.1",
       "AppFileName": "$(InstallPath)\\tflint.exe",
       "WebDownloadFile": "https://github.com/terraform-linters/tflint/releases/download/v$(Version)/tflint_windows_amd64.zip",
       "DownloadedFile": "tflint.zip",
@@ -220,7 +239,8 @@
       "InstallPath": "$(ProgramFiles)\\TFLint",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
-      "StoredHash": "34A3CF6F9FBA5DD5DC102EA474A3B9B218FDDDD39B09EF4928822F2A03803DA5"
+      "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14",
+      "AddToPath": true
     },
     {
       "Name": "Visual Studio 2022",

--- a/dev-setup/argo-cd.json
+++ b/dev-setup/argo-cd.json
@@ -3,16 +3,17 @@
     "NbuildAppList": [
       {
         "Name": "Argo CD",
-        "Version": "2.9.3",
+        "Version": "2.14.5",
         "AppFileName": "$(InstallPath)\\argocd.exe",
         "WebDownloadFile": "https://github.com/argoproj/argo-cd/releases/download/v$(Version)/argocd-windows-amd64.exe",
         "DownloadedFile": "argocd.exe",
         "InstallCommand": "xcopy.exe",
-        "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",      
-        "InstallPath": "$(ProgramFiles)\\ArgoCD\\",
+        "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
+        "InstallPath": "$(ProgramFiles)\\ArgoCD",
         "UninstallCommand": "powershell.exe",
-        "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\argocd.exe' -Force; if ((Get-ChildItem -Path '$(InstallPath)' -Force).Count -eq 0) { Remove-Item -Path '$(InstallPath)' -Force }; Write-Output 'ArgoCD CLI uninstalled.'\"",
-        "StoredHash": null
+        "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+        "StoredHash": "D93E14EEBE6FD0B8F6677D95617982B7C9D73617D3F714C36D19C087C0E7A9FB",
+        "AddToPath": true
       }
     ]
   }

--- a/dev-setup/azure-cli.json
+++ b/dev-setup/azure-cli.json
@@ -3,15 +3,16 @@
     "NbuildAppList": [
       {
         "Name": "AzureCLI",
-        "Version": "2.63.0",
-        "AppFileName": "$(InstallPath)\\az.exe",
-        "WebDownloadFile": "https://aka.ms/installazurecliwindows",
+        "Version": "2.70.0",
+        "AppFileName": "$(InstallPath)\\az.cmd",
+        "WebDownloadFile": "https://azcliprod.blob.core.windows.net/msi/azure-cli-$(Version)-x64.msi",
         "DownloadedFile": "AzureCLI-$(Version)-win-x64.msi",
         "InstallCommand": "msiexec.exe",
-        "InstallArgs": "/i AzureCLI-$(Version)-win-x64.msi /quiet",
-        "InstallPath": "$(ProgramFiles)\\AzureCLI",
+        "InstallArgs": "/i AzureCLI-$(Version)-win-x64.msi /quiet" ,
+        "InstallPath": "$(ProgramFiles)\\Microsoft SDKs\\Azure\\CLI2\\wbin",
         "UninstallCommand": "msiexec.exe",
-        "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet"
+        "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet",
+        "StoredHash" : "F24C501B242614AFA989ACF22719C816BE87E7AC1FF8FF84C5FA200751F30FE2"
       }
     ]
   }

--- a/dev-setup/git_for_windows.json
+++ b/dev-setup/git_for_windows.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Git for Windows",
-      "Version": "2.47.1",
+      "Version": "2.48.1",
       "AppFileName": "$(InstallPath)\\bin\\git.exe",
       "WebDownloadFile": "https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe",
       "DownloadedFile": "Git-$(Version)-64-bit.exe",

--- a/dev-setup/git_for_windows.json
+++ b/dev-setup/git_for_windows.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Git for Windows",
-      "Version": "2.48.1",
+      "Version": "2.49.0",
       "AppFileName": "$(InstallPath)\\bin\\git.exe",
       "WebDownloadFile": "https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe",
       "DownloadedFile": "Git-$(Version)-64-bit.exe",

--- a/dev-setup/install.psm1
+++ b/dev-setup/install.psm1
@@ -366,11 +366,6 @@ function GetFileVersion {
     return ($versionInfo.FileMajorPart, $versionInfo.FileMinorPart, $versionInfo.FileBuildPart, $versionInfo.FilePrivatePart) -join "."
 }
 
-    # Call GetFileVersion function with the specified path
-    return GetFileVersion -FilePath $FilePath
-}
-
-
 <#
     Function: EnsureMinikubeRunning
     Description: Checks if Minikube is running and starts it if not.

--- a/dev-setup/install.psm1
+++ b/dev-setup/install.psm1
@@ -25,7 +25,7 @@
     | Write-OutputMessage         | Writes output messages to the console and log files.          |
     | GetFileVersion              | Retrieves the file version of a specified file.               |
     | EnsureMinikubeRunning       | Checks if Minikube is running and starts it if not.           |
-    | MainFileVersion             | Main function to get the file version.                        |
+
 .EXAMPLE
     Import-Module ./install.psm1
     PrepareDownloadsDirectory -directory "C:\NToolsDownloads"
@@ -40,7 +40,6 @@
     SetDevEnvironmentVariables -devDrive "D:" -mainDir "C:\MainDir"
     Write-OutputMessage -Prefix "Info" -Message "Installation completed successfully."
     GetFileVersion -FilePath "C:\Program Files\NBuild\nb.exe"
-    MainFileVersion -FilePath "C:\Program Files\NBuild\nb.exe"
 
 .NOTES
 
@@ -143,7 +142,7 @@ function CheckIfAppInstalled {
      {
         # check if the version is correct
         #$installedVersion = & .\file-version.ps1 $appInfo.AppFileName
-        $installedVersion = MainFileVersion -FilePath $appInfo.AppFileName
+        $installedVersion = GetFileVersion -FilePath $appInfo.AppFileName
         $targetVersion = $appInfo.Version
         Write-Host "$($appInfo.Name)  version: $($appInfo.Version) is found."
 
@@ -366,11 +365,6 @@ function GetFileVersion {
     # return the all file version parts joined by a dot
     return ($versionInfo.FileMajorPart, $versionInfo.FileMinorPart, $versionInfo.FileBuildPart, $versionInfo.FilePrivatePart) -join "."
 }
-
-function MainFileVersion {
-    param (
-        [string]$FilePath
-    )
 
     # Call GetFileVersion function with the specified path
     return GetFileVersion -FilePath $FilePath

--- a/dev-setup/install.psm1
+++ b/dev-setup/install.psm1
@@ -24,6 +24,7 @@
     | SetDevEnvironmentVariables  | Sets development environment variables.                       |
     | Write-OutputMessage         | Writes output messages to the console and log files.          |
     | GetFileVersion              | Retrieves the file version of a specified file.               |
+    | EnsureMinikubeRunning       | Checks if Minikube is running and starts it if not.           |
     | MainFileVersion             | Main function to get the file version.                        |
 .EXAMPLE
     Import-Module ./install.psm1
@@ -375,4 +376,22 @@ function MainFileVersion {
     return GetFileVersion -FilePath $FilePath
 }
 
-Export-ModuleMember -Function PrepareDownloadsDirectory, GetAppInfo, CheckIfAppInstalled, Install, MainInstallApp, CheckIfDotnetInstalled, InstallDotNetCore, MainInstallNtools, SetDevEnvironmentVariables, Write-OutputMessage, GetFileVersion, MainFileVersion, nbExePath
+
+<#
+    Function: EnsureMinikubeRunning
+    Description: Checks if Minikube is running and starts it if not.
+#>
+
+function EnsureMinikubeRunning {
+    # Check if Minikube is running
+    $minikubeStatus = sudo minikube status | Select-String "host: Running"
+
+    if ($minikubeStatus) {
+        Write-Host "Minikube is already running."
+    } else {
+        Write-Host "Starting Minikube..."
+        sudo minikube start --driver=hyperv --cpus=2 --memory=6144 --disk-size=20g
+    }
+}
+
+Export-ModuleMember -Function *

--- a/dev-setup/k8s.json
+++ b/dev-setup/k8s.json
@@ -12,7 +12,8 @@
       "InstallPath": "$(ProgramFiles)\\kubectl\\",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(ProgramFiles)\\kubectl\\kubectl.exe' -Force; [Environment]::SetEnvironmentVariable('Path', $env:Path -replace ';$(ProgramFiles)\\kubectl', '', [EnvironmentVariableTarget]::Machine); Write-Output 'kubectl uninstalled.'\"",
-      "StoredHash": "CF51A1C6BF3B6BA6A5B549D1DEBF8AA6AFB00C4C5A3D5D4BB1072F54CBE4390F"
+      "StoredHash": "CF51A1C6BF3B6BA6A5B549D1DEBF8AA6AFB00C4C5A3D5D4BB1072F54CBE4390F",
+      "AddToPath": true
     }
   ]
 }

--- a/dev-setup/k8s.json
+++ b/dev-setup/k8s.json
@@ -3,16 +3,16 @@
   "NbuildAppList": [
     {
       "Name": "kubectl",
-      "Version": "1.32.2",
+      "Version": "1.32.3",
       "AppFileName": "$(InstallPath)\\kubectl.exe",
       "WebDownloadFile": "https://dl.k8s.io/release/v$(Version)/bin/windows/amd64/kubectl.exe",
       "DownloadedFile": "kubectl.exe",
       "InstallCommand": "xcopy.exe",
-      "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",      
-      "InstallPath": "$(ProgramFiles)\\kubectl\\",
+      "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
+      "InstallPath": "$(ProgramFiles)\\kubectl",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"Remove-Item -Path '$(ProgramFiles)\\kubectl\\kubectl.exe' -Force; [Environment]::SetEnvironmentVariable('Path', $env:Path -replace ';$(ProgramFiles)\\kubectl', '', [EnvironmentVariableTarget]::Machine); Write-Output 'kubectl uninstalled.'\"",
-      "StoredHash": "CF51A1C6BF3B6BA6A5B549D1DEBF8AA6AFB00C4C5A3D5D4BB1072F54CBE4390F",
+      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+      "StoredHash": "3fd1576a902ecf713f7d6390ae01799e370883e0341177ee09dbdc362db953e3",
       "AddToPath": true
     }
   ]

--- a/dev-setup/minikube.json
+++ b/dev-setup/minikube.json
@@ -9,12 +9,13 @@
         "DownloadedFile": "minikube-installer.exe",
         "InstallCommand": "powershell.exe",
         "InstallArgs": "-Command \"Start-Process -FilePath '$(DownloadedFile)' -ArgumentList '/S' -Wait; ",
-        "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube\\",
+        "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube",
         "UninstallCommand": "powershell.exe",
-        "UninstallArgs": "-Command \"$uninstaller = '$(InstallPath)\\Uninstall Minikube.exe'; if (Test-Path $uninstaller) { Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait; Write-Output 'Minikube uninstalled.' } else { Write-Output 'Minikube uninstaller not found.' }\"",
+        "UninstallArgs": "-Command \"Start-Process -FilePath '$(InstallPath)\\Uninstall.exe' -ArgumentList '/S' -Wait;\"",
         "PostInstallCommand": "powershell.exe",
         "PostInstallArgs": "-Command \"minikube start --driver=docker\"",
-        "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA"
+        "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA",
+        "AddToPath": true
       }
     ]
   }

--- a/dev-setup/mongo-db.json
+++ b/dev-setup/mongo-db.json
@@ -11,7 +11,6 @@
       "InstallArgs": "/q /i $(DownloadedFile) INSTALLLOCATION=\"$(InstallPath)\" ADDLOCAL=\"all\"",
       "InstallPath": "$(ProgramFiles)\\MongoDB\\Server",
       "UninstallCommand": "msiexec.exe",
-      "UninstallCommand": "msiexec.exe",
       "UninstallArgs": "/x {CDE275B4-7DCB-4D35-AD3E-AB7A4EB36CBB} /qn"
     }
   ]

--- a/dev-setup/ntools.json
+++ b/dev-setup/ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.9.0",
+      "Version": "1.10.1",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/dev-setup/ntools.json
+++ b/dev-setup/ntools.json
@@ -11,7 +11,8 @@
       "InstallArgs": "-Command Expand-Archive -Path $(Version).zip -DestinationPath \u0027$(InstallPath)\u0027 -Force",
       "InstallPath": "$(ProgramFiles)\\Nbuild",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command Remove-Item -Path \u0027$(InstallPath)\u0027 -Recurse -Force"
+      "UninstallArgs": "-Command Remove-Item -Path \u0027$(InstallPath)\u0027 -Recurse -Force",
+      "AddToPath": true
     }
   ]
 }

--- a/dev-setup/terraform.json
+++ b/dev-setup/terraform.json
@@ -9,10 +9,11 @@
       "DownloadedFile": "terraform_$(Version)_windows_amd64.zip",
       "InstallCommand": "powershell.exe",
       "InstallArgs": "-Command \"Expand-Archive -Path '$(DownloadedFile)' -DestinationPath '$(InstallPath)'\" -Force",
-      "InstallPath": "$(ProgramFiles)\\Terraform\\",
+      "InstallPath": "$(ProgramFiles)\\Terraform",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\terraform.exe' -Force\"",
-      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C"
+      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C",
+      "AddToPath": true
     }
   ]
 }

--- a/dev-setup/tflint.json
+++ b/dev-setup/tflint.json
@@ -12,7 +12,8 @@
         "InstallPath": "$(ProgramFiles)\\TFLint",
         "UninstallCommand": "powershell.exe",
         "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
-        "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14"
+        "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14",
+        "AddToPath": true
       }
     ]
   }

--- a/dev-setup/vs-code.json
+++ b/dev-setup/vs-code.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Visual Studio Code",
-      "Version": "1.98.0",
+      "Version": "1.98.2",
       "AppFileName": "$(InstallPath)\\Code.exe",
       "WebDownloadFile": "https://aka.ms/win32-x64-system-stable",
       "DownloadedFile": "VSCodeSetup-x64-$(Version).exe",

--- a/docs/ntools/ntools.md
+++ b/docs/ntools/ntools.md
@@ -25,3 +25,6 @@ The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-envi
 | [NuGet](https://www.nuget.org/downloads)                                                                 | 6.13.2      | 10-mar-25       |
 | [SysInternals](https://learn.microsoft.com/en-us/sysinternals/)                                          | 2.90.0      | 22-Jun-24       |
 | [Python](https://www.python.org/downloads/)                                                               | 3.13.2      | 10-mar-25       |
+| [Argo CD](https://github.com/argoproj/argo-cd/releases/)                                          | 2.14.5      | 12-mar-25       |
+| [minikube](https://github.com/kubernetes/minikube/releases/)                                          | 2.14.5      | 12-mar-25       |
+| [kubernetes](https://github.com/kubernetes/kubernetes/releases)                                          | 1.32.2      | 12-mar-25       |

--- a/docs/ntools/ntools.md
+++ b/docs/ntools/ntools.md
@@ -6,7 +6,7 @@ The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-envi
 
 | Tool                                                                                                       | Version     | Last Checked on |
 | :--------------------------------------------------------------------------------------------------------- | :---------- | :-------------- |
-| [Git for Windows](https://git-scm.com/downloads)                                                          | 2.48.1      | 10-Mar-25       |
+| [Git for Windows](https://git-scm.com/downloads)                                                          | 2.49.0      | 18-Mar-25       |
 | [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701)                       | 1.21.10351.0| 10-Mar-25       |
 | [Download MongoDB Community Server](https://www.mongodb.com/try/download/community)                       | 8.0.5       | 10-Mar-25       |
 | [Terraform](https://releases.hashicorp.com/terraform)                                                    | 1.11.1      | 09-Mar-25       |

--- a/docs/ntools/ntools.md
+++ b/docs/ntools/ntools.md
@@ -1,25 +1,27 @@
 ### Windows Dev Environment
+
 The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-environment/) has good information on how to setup a Windows dev environment.
 
-- The table below list the latest dev tools used in Ntoots.
+- The table below list the latest dev tools used in Ntools.
 
-| Tool| Version | Last Checked on |
-| --- | --- | --- |
-| [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701?activetab=pivot:overviewtab) |  1.20.11781.0 | 28-jul-24 |
-| [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/vs/community/) |  17.11.3 | 14-sep-24 |
-| [Visual Studio Code](https://code.visualstudio.com/download) |  1.98.0 | 06-mar-25 |
-| [Git](https://git-scm.com/downloads) |   2.47.1 | 07-dec-24 |
-| [Node.js](https://nodejs.org/en/download/) |   20.17.0 | 10-sep-24 |
-| [Download Postman Get Started for Free](https://www.postman.com/downloads/) |   v110.24.27 | 14-sep-24 |
-| [Install Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/) |  4.38.0.0 | 03-mar-25 |
-| [Download MongoDB Community Server](https://www.mongodb.com/try/download/community) |  7.0.12 | 28-jul-24 |
-| [Download .NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) |   9.0.100 | 15-nov-24 |
-| [Burp Suite](https://portswigger.net/burp/communitydownload) |   2021.11.2 | Oct 1, 2023 |
-| [Draw.io](https://app.diagrams.net/) |   --- | Oct 1, 2023 |
-| [Dotnet Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/9.0.2)) | 9.0.0 | 03-mar-25 |
-| [PowerShell](https://github.com/PowerShell/PowerShell/releases) | 7.5.0 | 25-jan-25 |
-| [Nuget](https://www.nuget.org/downloads) |  6.12.1 | 07-dec-24 |
-| [SysInternals]() |  2.90.0 | 22-jun-24 |
-| [Python]() | 3.12.6 | 10-sep-24 |
-| [Terraform](https://releases.hashicorp.com/terraform) | 1.11.1 | 09-mar-24 |
-| [Terraform Lint](https://github.com/terraform-linters/tflint/releases) | 0.55.1 | 09-mar-24 |
+| Tool                                                                                                       | Version     | Last Checked on |
+| :--------------------------------------------------------------------------------------------------------- | :---------- | :-------------- |
+| [Git for Windows](https://git-scm.com/downloads)                                                          | 2.48.1      | 10-Mar-25       |
+| [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701)                       | 1.21.10351.0| 10-Mar-25       |
+| [Download MongoDB Community Server](https://www.mongodb.com/try/download/community)                       | 8.0.5       | 10-Mar-25       |
+| [Terraform](https://releases.hashicorp.com/terraform)                                                    | 1.11.1      | 09-Mar-25       |
+| [Terraform Lint](https://github.com/terraform-linters/tflint/releases)                                  | 0.55.1      | 09-Mar-25       |
+| [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?pivots=msi)            | 2.70.0      | 10-Mar-25       |
+| [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/vs/community/)                | 17.11.3     | 14-Sep-24       |
+| [Visual Studio Code](https://code.visualstudio.com/download)                                             | 1.98.0      | 06-Mar-25       |
+| [Node.js](https://nodejs.org/en/download/)                                                               | 22.14.1     | 10-mar-25       |
+| [Download Postman Get Started for Free](https://www.postman.com/downloads/)                               | v11.36.0  | 10-mar-25       |
+| [Install Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/)                 | 4.38.0.0    | 03-Mar-25       |
+| [Download .NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)           | 9.0.100     | 15-Nov-24       |
+| [Burp Suite](https://portswigger.net/burp/communitydownload)                                             | 2021.11.2   | 01-Oct-23       |
+| [Draw.io](https://app.diagrams.net/)                                                                     | N/A         | 01-Oct-23       |
+| [Dotnet Runtime](https://dotnet.microsoft.com/en-us/download/dotnet)                               | 9.0.2       | 10-Mar-25       |
+| [PowerShell](https://github.com/PowerShell/PowerShell/releases)                                          | 7.5.0       | 25-Jan-25       |
+| [NuGet](https://www.nuget.org/downloads)                                                                 | 6.13.2      | 10-mar-25       |
+| [SysInternals](https://learn.microsoft.com/en-us/sysinternals/)                                          | 2.90.0      | 22-Jun-24       |
+| [Python](https://www.python.org/downloads/)                                                               | 3.13.2      | 10-mar-25       |

--- a/docs/ntools/ntools.md
+++ b/docs/ntools/ntools.md
@@ -13,7 +13,7 @@ The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-envi
 | [Terraform Lint](https://github.com/terraform-linters/tflint/releases)                                  | 0.55.1      | 09-Mar-25       |
 | [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?pivots=msi)            | 2.70.0      | 10-Mar-25       |
 | [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/vs/community/)                | 17.11.3     | 14-Sep-24       |
-| [Visual Studio Code](https://code.visualstudio.com/download)                                             | 1.98.0      | 06-Mar-25       |
+| [Visual Studio Code](https://code.visualstudio.com/download)                                             | 1.98.2      | 06-Mar-25       |
 | [Node.js](https://nodejs.org/en/download/)                                                               | 22.14.1     | 10-mar-25       |
 | [Download Postman Get Started for Free](https://www.postman.com/downloads/)                               | v11.36.0  | 10-mar-25       |
 | [Install Docker Desktop on Windows](https://docs.docker.com/docker-for-windows/install/)                 | 4.38.0.0    | 03-Mar-25       |

--- a/go/apps.json
+++ b/go/apps.json
@@ -89,7 +89,7 @@
     },
     {
       "Name": "Git for Windows",
-      "Version": "2.48.1",
+      "Version": "2.49.0",
       "AppFileName": "$(InstallPath)\\bin\\git.exe",
       "WebDownloadFile": "https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe",
       "DownloadedFile": "Git-$(Version)-64-bit.exe",

--- a/go/apps.json
+++ b/go/apps.json
@@ -15,27 +15,29 @@
     },
     {
       "Name": "Argo CD",
-      "Version": "2.9.3",
+      "Version": "2.14.5",
       "AppFileName": "$(InstallPath)\\argocd.exe",
       "WebDownloadFile": "https://github.com/argoproj/argo-cd/releases/download/v$(Version)/argocd-windows-amd64.exe",
       "DownloadedFile": "argocd.exe",
       "InstallCommand": "xcopy.exe",
       "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
-      "InstallPath": "$(ProgramFiles)\\ArgoCD\\",
+      "InstallPath": "$(ProgramFiles)\\ArgoCD",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\argocd.exe' -Force; if ((Get-ChildItem -Path '$(InstallPath)' -Force).Count -eq 0) { Remove-Item -Path '$(InstallPath)' -Force }; Write-Output 'ArgoCD CLI uninstalled.'\""
+      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+      "StoredHash": "D93E14EEBE6FD0B8F6677D95617982B7C9D73617D3F714C36D19C087C0E7A9FB"
     },
     {
       "Name": "AzureCLI",
-      "Version": "2.63.0",
-      "AppFileName": "$(InstallPath)\\az.exe",
-      "WebDownloadFile": "https://aka.ms/installazurecliwindows",
+      "Version": "2.70.0",
+      "AppFileName": "$(InstallPath)\\az.cmd",
+      "WebDownloadFile": "https://azcliprod.blob.core.windows.net/msi/azure-cli-$(Version)-x64.msi",
       "DownloadedFile": "AzureCLI-$(Version)-win-x64.msi",
       "InstallCommand": "msiexec.exe",
       "InstallArgs": "/i AzureCLI-$(Version)-win-x64.msi /quiet",
-      "InstallPath": "$(ProgramFiles)\\AzureCLI",
+      "InstallPath": "$(ProgramFiles)\\Microsoft SDKs\\Azure\\CLI2\\wbin",
       "UninstallCommand": "msiexec.exe",
-      "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet"
+      "UninstallArgs": "/x AzureCLI-$(Version)-win-x64.msi /quiet",
+      "StoredHash": "F24C501B242614AFA989ACF22719C816BE87E7AC1FF8FF84C5FA200751F30FE2"
     },
     {
       "Name": "AzurePowershell",
@@ -62,10 +64,22 @@
       "UninstallArgs": "-Command \"\u0026 {Start-Process -FilePath '$(InstallPath)\\Docker Desktop Installer.exe' -ArgumentList 'uninstall --quiet' -NoNewWindow -Wait; while ((Get-Process 'Docker Desktop Installer' -ErrorAction SilentlyContinue) -or (Get-Process 'Docker' -ErrorAction SilentlyContinue)) { Start-Sleep -Seconds 5 }}\""
     },
     {
-      "Name": "Dotnet Runtime",
-      "Version": "8.0.1",
+      "Name": "Dotnet Desktop Runtime",
+      "Version": "9.0.2",
       "AppFileName": "$(InstallPath)\\dotnet.exe",
-      "WebDownloadFile": "https://download.visualstudio.microsoft.com/download/pr/f18288f6-1732-415b-b577-7fb46510479a/a98239f751a7aed31bc4aa12f348a9bf/windowsdesktop-runtime-$(Version)-win-x64.exe",
+      "WebDownloadFile": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/$(Version)/windowsdesktop-runtime-$(Version)-win-x64.exe",
+      "DownloadedFile": "dotnet_installer.exe",
+      "InstallCommand": "dotnet_installer.exe",
+      "InstallArgs": "/quiet /norestart\"",
+      "InstallPath": "$(ProgramFiles)\\dotnet",
+      "UninstallCommand": "dotnet_installer.exe",
+      "UninstallArgs": "/uninstall /quiet /norestart"
+    },
+    {
+      "Name": "Dotnet Runtime",
+      "Version": "9.0.2",
+      "AppFileName": "$(InstallPath)\\dotnet.exe",
+      "WebDownloadFile": "https://builds.dotnet.microsoft.com/dotnet/Runtime/$(Version)/dotnet-runtime-$(Version)-win-x64.exe",
       "DownloadedFile": "dotnet_installer.exe",
       "InstallCommand": "dotnet_installer.exe",
       "InstallArgs": "/quiet /norestart\"",
@@ -75,7 +89,7 @@
     },
     {
       "Name": "Git for Windows",
-      "Version": "2.47.1",
+      "Version": "2.48.1",
       "AppFileName": "$(InstallPath)\\bin\\git.exe",
       "WebDownloadFile": "https://github.com/git-for-windows/git/releases/download/v$(Version).windows.1/Git-$(Version)-64-bit.exe",
       "DownloadedFile": "Git-$(Version)-64-bit.exe",
@@ -100,16 +114,16 @@
     },
     {
       "Name": "kubectl",
-      "Version": "1.32.2",
+      "Version": "1.32.3",
       "AppFileName": "$(InstallPath)\\kubectl.exe",
       "WebDownloadFile": "https://dl.k8s.io/release/v$(Version)/bin/windows/amd64/kubectl.exe",
       "DownloadedFile": "kubectl.exe",
       "InstallCommand": "xcopy.exe",
       "InstallArgs": "$(DownloadedFile) \"$(InstallPath)\\\" /d /y",
-      "InstallPath": "$(ProgramFiles)\\kubectl\\",
+      "InstallPath": "$(ProgramFiles)\\kubectl",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"Remove-Item -Path '$(ProgramFiles)\\kubectl\\kubectl.exe' -Force; [Environment]::SetEnvironmentVariable('Path', $env:Path -replace ';$(ProgramFiles)\\kubectl', '', [EnvironmentVariableTarget]::Machine); Write-Output 'kubectl uninstalled.'\"",
-      "StoredHash": "CF51A1C6BF3B6BA6A5B549D1DEBF8AA6AFB00C4C5A3D5D4BB1072F54CBE4390F"
+      "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
+      "StoredHash": "3fd1576a902ecf713f7d6390ae01799e370883e0341177ee09dbdc362db953e3"
     },
     {
       "Name": "minikube",
@@ -119,9 +133,9 @@
       "DownloadedFile": "minikube-installer.exe",
       "InstallCommand": "powershell.exe",
       "InstallArgs": "-Command \"Start-Process -FilePath '$(DownloadedFile)' -ArgumentList '/S' -Wait; ",
-      "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube\\",
+      "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command \"$uninstaller = '$(InstallPath)\\Uninstall Minikube.exe'; if (Test-Path $uninstaller) { Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait; Write-Output 'Minikube uninstalled.' } else { Write-Output 'Minikube uninstaller not found.' }\"",
+      "UninstallArgs": "-Command \"Start-Process -FilePath '$(InstallPath)\\Uninstall.exe' -ArgumentList '/S' -Wait;\"",
       "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA"
     },
     {
@@ -198,20 +212,20 @@
     },
     {
       "Name": "Terraform",
-      "Version": "1.9.5",
+      "Version": "1.11.1",
       "AppFileName": "$(InstallPath)\\terraform.exe",
       "WebDownloadFile": "https://releases.hashicorp.com/terraform/$(Version)/terraform_$(Version)_windows_amd64.zip",
       "DownloadedFile": "terraform_$(Version)_windows_amd64.zip",
       "InstallCommand": "powershell.exe",
       "InstallArgs": "-Command \"Expand-Archive -Path '$(DownloadedFile)' -DestinationPath '$(InstallPath)'\" -Force",
-      "InstallPath": "$(ProgramFiles)\\Terraform\\",
+      "InstallPath": "$(ProgramFiles)\\Terraform",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\terraform.exe' -Force\"",
-      "StoredHash": "9A9B81018E40DADBC1EDA63C95C601878A5CA0CD4EF52A87DE0DE940F88E93C9"
+      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C"
     },
     {
       "Name": "terraform lint",
-      "Version": "0.53.0",
+      "Version": "0.55.1",
       "AppFileName": "$(InstallPath)\\tflint.exe",
       "WebDownloadFile": "https://github.com/terraform-linters/tflint/releases/download/v$(Version)/tflint_windows_amd64.zip",
       "DownloadedFile": "tflint.zip",
@@ -220,7 +234,7 @@
       "InstallPath": "$(ProgramFiles)\\TFLint",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
-      "StoredHash": "34A3CF6F9FBA5DD5DC102EA474A3B9B218FDDDD39B09EF4928822F2A03803DA5"
+      "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14"
     },
     {
       "Name": "Visual Studio 2022",

--- a/go/apps.json
+++ b/go/apps.json
@@ -24,7 +24,8 @@
       "InstallPath": "$(ProgramFiles)\\ArgoCD",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
-      "StoredHash": "D93E14EEBE6FD0B8F6677D95617982B7C9D73617D3F714C36D19C087C0E7A9FB"
+      "StoredHash": "D93E14EEBE6FD0B8F6677D95617982B7C9D73617D3F714C36D19C087C0E7A9FB",
+      "AddToPath": true
     },
     {
       "Name": "AzureCLI",
@@ -123,7 +124,8 @@
       "InstallPath": "$(ProgramFiles)\\kubectl",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\' -Recurse -Force\"",
-      "StoredHash": "3fd1576a902ecf713f7d6390ae01799e370883e0341177ee09dbdc362db953e3"
+      "StoredHash": "3fd1576a902ecf713f7d6390ae01799e370883e0341177ee09dbdc362db953e3",
+      "AddToPath": true
     },
     {
       "Name": "minikube",
@@ -136,7 +138,8 @@
       "InstallPath": "$(ProgramFiles)\\Kubernetes\\Minikube",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Start-Process -FilePath '$(InstallPath)\\Uninstall.exe' -ArgumentList '/S' -Wait;\"",
-      "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA"
+      "StoredHash": "7B7D2DCB130DC066D6F2D01DD1A54B92A35F8F7B0F849283A8BF4455DFF8DAEA",
+      "AddToPath": true
     },
     {
       "Name": "MongoDB",
@@ -152,7 +155,7 @@
     },
     {
       "Name": "Ntools",
-      "Version": "1.9.0",
+      "Version": "1.10.1",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",
@@ -160,7 +163,8 @@
       "InstallArgs": "-Command Expand-Archive -Path $(Version).zip -DestinationPath '$(InstallPath)' -Force",
       "InstallPath": "$(ProgramFiles)\\Nbuild",
       "UninstallCommand": "powershell.exe",
-      "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force"
+      "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
+      "AddToPath": true
     },
     {
       "Name": "Nuget",
@@ -221,7 +225,8 @@
       "InstallPath": "$(ProgramFiles)\\Terraform",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command \"Remove-Item -Path '$(InstallPath)\\terraform.exe' -Force\"",
-      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C"
+      "StoredHash": "990EA1F1665D1B4E0C827AB39D6835E949928DEC28D5458B3C429778041FF72C",
+      "AddToPath": true
     },
     {
       "Name": "terraform lint",
@@ -234,7 +239,8 @@
       "InstallPath": "$(ProgramFiles)\\TFLint",
       "UninstallCommand": "powershell.exe",
       "UninstallArgs": "-Command Remove-Item -Path '$(InstallPath)' -Recurse -Force",
-      "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14"
+      "StoredHash": "2F4D6E4D96F817938DA43E786E4F2E97791CA15962DAE4EF8EF97D0A0CD49A14",
+      "AddToPath": true
     },
     {
       "Name": "Visual Studio 2022",

--- a/go/apps.json
+++ b/go/apps.json
@@ -250,7 +250,7 @@
     },
     {
       "Name": "Visual Studio Code",
-      "Version": "1.98.0",
+      "Version": "1.98.2",
       "AppFileName": "$(InstallPath)\\Code.exe",
       "WebDownloadFile": "https://aka.ms/win32-x64-system-stable",
       "DownloadedFile": "VSCodeSetup-x64-$(Version).exe",

--- a/go/build-apps.go
+++ b/go/build-apps.go
@@ -104,6 +104,7 @@ func main() {
         UninstallCommand string `json:"UninstallCommand"`
         UninstallArgs   string `json:"UninstallArgs"`
         StoredHash      string `json:"StoredHash,omitempty"`
+        AddToPath       bool `json:"AddToPath,omitempty"`
     }
 
     type FileContent struct {

--- a/nBackup/nBackup.csproj
+++ b/nBackup/nBackup.csproj
@@ -9,7 +9,7 @@
     <Authors>naz-hage</Authors>
     <Company>naz-hage</Company>
     <Product>Backup automation</Product>
-    <Copyright>2020-2024</Copyright>
+    <Copyright>2020-2025</Copyright>
   </PropertyGroup>
 
 

--- a/nBackupTests/NbackupTests.csproj
+++ b/nBackupTests/NbackupTests.csproj
@@ -22,9 +22,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/nBackupTests/nBackupTests.csproj
+++ b/nBackupTests/nBackupTests.csproj
@@ -22,9 +22,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -51,7 +51,7 @@
 		<PropertyGroup>
 			<FileName>$(SolutionDir)\$(TargetRelease)\nb.exe</FileName>
 		</PropertyGroup>
-		<Exec Command='powershell -File "$(BuildTools)\file-version.ps1" "$(FileName)"' ConsoleToMSBuild="true">
+		<Exec Command='powershell -File "$(SolutionDir)\dev-setup\list-file-version.ps1" "$(FileName)"' ConsoleToMSBuild="true">
 			<Output TaskParameter="ConsoleOutput" PropertyName="Version" />
 		</Exec>
 		<Message Text="Powershell File version: $(Version)" />


### PR DESCRIPTION
Added functionality to manage the system PATH in `Command.cs` with methods to add, remove, and check the install path. Introduced `AddToPath` property in `NbuildApp.cs` to control PATH addition. Added `CmdPath` command in `Program.cs` to display PATH segments. Updated `CommandTests.cs` with unit tests for PATH methods. Updated JSON files for Azure CLI, Git for Windows, and Kubernetes to reflect new versions and `AddToPath` property. Updated `ntools.md` with latest tool versions and URLs.