### PR TITLE
Issue 90: Address comments from previous PR

### DIFF
--- a/GitHubRelease/ApiService.cs
+++ b/GitHubRelease/ApiService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+﻿using System.Net.Http.Headers;
 
 namespace GitHubRelease
 {
@@ -31,13 +31,18 @@ namespace GitHubRelease
         /// <summary>
         /// Sets up the headers for making API requests.
         /// </summary>
-        /// <param name="token">The access token for authentication.</param>
+        /// <param name="download">Indicates whether the request is for downloading content.</param>
+        /// <remarks>
+        /// - If <paramref name="download"/> is true, the headers are configured for downloading files.
+        /// - If <paramref name="download"/> is false, the headers are configured for standard API requests.
+        /// - The method uses the access token from <see cref="Credentials.GetToken()"/> for authentication.
+        /// </remarks>
         public void SetupHeaders(bool download = false)
         {
             Client.DefaultRequestHeaders.Clear();
             Client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Credentials.GetToken()}");
             Client.DefaultRequestHeaders.Add("User-Agent", "request");
-            
+
             if (download)
             {
                 Client.DefaultRequestHeaders.Add("Accept", "application/octet-stream");
@@ -45,7 +50,7 @@ namespace GitHubRelease
             }
             else
             {
-                Client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json")); // Accept JSON for metadata
             }
         }
 

--- a/GitHubRelease/Cli.cs
+++ b/GitHubRelease/Cli.cs
@@ -30,7 +30,10 @@ namespace GitHubRelease
         /// <summary>
         /// Gets or sets the repository name in the format userName/repoName.
         /// </summary>
-        [OptionalArgument("", "repo", "Specifies the Git repository in the format userName/repoName. Applicable to all commands.")]
+        [OptionalArgument("", "repo", "Specifies the Git repository in the format any of the following fortmats: \n" +
+            "\t repoName  (UserName is declared the `OWNER` environment variable) \n"+
+            "\t userName/repoName\n" +
+            "\t https://github.com/userName/repoName (Full URL to the repository on GitHub). This is applicable to all commands.")]
         public string? Repo { get; set; }
 
         /// <summary>
@@ -93,7 +96,6 @@ namespace GitHubRelease
                 throw new ArgumentException("The 'repo' option is required for all commands and must be in the format userName/repoName.");
             }
 
-
             // Use the new ValidateRepo method
             ValidateRepo().GetAwaiter().GetResult();
 
@@ -153,6 +155,19 @@ namespace GitHubRelease
             // If the repo contains a slash, it must be in the format userName/repoName
             // otherwise, it is expected to be a repoName, in which case
             // the UserName is derived from the OWNER environment variable
+
+            // Check if the input is a full URL
+            if (Repo!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
+            {
+                // Extract the userName/repoName portion
+                var uri = new Uri(Repo);
+                if (uri.Host != "github.com")
+                {
+                    throw new ArgumentException("Only repositories hosted on github.com are supported.");
+                }
+
+                Repo = uri.AbsolutePath.Trim('/'); // Extracts "userName/repoName"
+            }
 
             var repoParts = Repo!.Split('/');
             if (repoParts.Length == 1)

--- a/GitHubRelease/Cli.cs
+++ b/GitHubRelease/Cli.cs
@@ -1,4 +1,5 @@
 using CommandLine.Attributes;
+using NbuildTasks;
 
 namespace GitHubRelease
 {
@@ -27,15 +28,15 @@ namespace GitHubRelease
         public CommandType Command { get; set; }
 
         /// <summary>
-        /// Gets or sets the repository name.
+        /// Gets or sets the repository name in the format userName/repoName.
         /// </summary>
-        [OptionalArgument("", "repo", "Specifies the repository name. Applicable to all commands.")]
+        [OptionalArgument("", "repo", "Specifies the Git repository in the format userName/repoName. Applicable to all commands.")]
         public string? Repo { get; set; }
 
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        [OptionalArgument("", "tag", "Specifies the tag name. Aplicable for all commands")]
+        [OptionalArgument("", "tag", "Specifies the tag name. Applicable for all commands")]
         public string? Tag { get; set; }
 
         /// <summary>
@@ -49,6 +50,7 @@ namespace GitHubRelease
         /// </summary>
         [OptionalArgument("", "file", "Specifies the asset file name. Must include full path. Applicable for create command")]
         public string? AssetFileName { get; set; }
+
         /// <summary>
         /// Gets or sets the asset path.
         /// </summary>
@@ -62,10 +64,10 @@ namespace GitHubRelease
         public bool Verbose { get; set; }
 
         private static readonly Dictionary<string, CommandType> CommandMap = new()
-            {
-                { "create", CommandType.create },
-                { "download", CommandType.download },
-            };
+                {
+                    { "create", CommandType.create },
+                    { "download", CommandType.download },
+                };
 
         /// <summary>
         /// Gets the command type from the command string.
@@ -88,12 +90,26 @@ namespace GitHubRelease
         {
             if (string.IsNullOrEmpty(Repo))
             {
-                throw new ArgumentException("The 'repo' option is required for all commands.");
+                throw new ArgumentException("The 'repo' option is required for all commands and must be in the format userName/repoName.");
             }
+
+            if (string.IsNullOrEmpty(Repo))
+            {
+                throw new ArgumentException("The 'repo' option is required for all commands and must be in the format userName/repoName.");
+            }
+
+            // Use the new ValidateRepo method
+            ValidateRepo().GetAwaiter().GetResult();
+
 
             if (string.IsNullOrEmpty(Tag))
             {
                 throw new ArgumentException("The 'tag' option is required for all commands.");
+            }
+
+            if (IsValidTag(Tag) == false)
+            {
+                throw new ArgumentException($"The 'tag' option '{Tag}' is not a valid tag format.");
             }
 
             if (Command == CommandType.create && string.IsNullOrEmpty(AssetFileName))
@@ -117,6 +133,94 @@ namespace GitHubRelease
             {
                 throw new ArgumentException("The 'path' option is required for the downloab commands and must be an absolute path.");
             }
+
+
+        }
+
+        /// <summary>
+        /// Validates the repository format and accessibility.
+        /// </summary>
+        /// <remarks>
+        /// If only the repository name (repoName) is provided without a userName, the method checks for the 
+        /// 'OWNER' environment variable. If 'OWNER' is set, it combines the OWNER value with the repoName 
+        /// to form the full repository string in the format userName/repoName. If 'OWNER' is not set, 
+        /// an exception is thrown.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown if the repository format is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if the OWNER environment variable is required but not set.</exception>
+        public async Task ValidateRepo()
+        {
+            // Validate the repo format
+            // 1. userName/repoName
+            // 2. repoName (OWNER environment variable must be set)
+            // https://github.com/{repo} must be accessible
+            // If the repo contains a slash, it must be in the format userName/repoName
+            // otherwise, it is expected to be a repoName, in which case
+            // the UserName is derived from the OWNER environment variable
+
+            var repoParts = Repo!.Split('/');
+            if (repoParts.Length == 1)
+            {
+                // If only the repoName is provided, ensure OWNER is set
+                var owner = Environment.GetEnvironmentVariable("OWNER");
+                if (string.IsNullOrEmpty(owner))
+                {
+                    throw new InvalidOperationException("The 'OWNER' environment variable is required when only the repository name is provided.");
+                }
+
+                // Combine OWNER and repoName to form userName/repoName
+                Repo = $"{owner}/{Repo}";
+
+            }
+            else if (repoParts.Length != 2 || string.IsNullOrEmpty(repoParts[0]) || string.IsNullOrEmpty(repoParts[1]))
+            {
+                throw new ArgumentException("The 'repo' option must be in the format userName/repoName.");
+            }
+
+            // Validate that the repository exists
+            await ValidateRepositoryExists();
+        }
+
+        public async Task ValidateRepositoryExists()
+        {
+            using var httpClient = new HttpClient();
+            var apiUrl = $"https://api.github.com/repos/{Repo}";
+            Console.WriteLine($"Validating repository via API: {apiUrl}");
+
+            try
+            {
+                // Add authentication if a GitHub token is available
+                var token = Credentials.GetToken();
+                if (!string.IsNullOrEmpty(token))
+                {
+                    Console.WriteLine("Using GitHub token for authentication.");
+                    httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                }
+
+                // Add required headers for GitHub API
+                httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("GitHubRelease/1.0");
+                httpClient.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+                // Send a GET request to the GitHub API
+                var response = await httpClient.GetAsync(apiUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new ArgumentException($"The repository '{Repo}' does not exist or is not accessible. HTTP Status: {response.StatusCode}");
+                }
+
+                Console.WriteLine($"Repository '{Repo}' is valid and accessible.");
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new ArgumentException($"Failed to validate the repository '{Repo}'. Error: {ex.Message}", ex);
+            }
+        }
+
+        private bool IsValidTag(string tag)
+        {
+            GitWrapper git = new();
+            return git.IsValidTag(tag);
         }
     }
 }
+

--- a/GitHubRelease/Cli.cs
+++ b/GitHubRelease/Cli.cs
@@ -93,10 +93,6 @@ namespace GitHubRelease
                 throw new ArgumentException("The 'repo' option is required for all commands and must be in the format userName/repoName.");
             }
 
-            if (string.IsNullOrEmpty(Repo))
-            {
-                throw new ArgumentException("The 'repo' option is required for all commands and must be in the format userName/repoName.");
-            }
 
             // Use the new ValidateRepo method
             ValidateRepo().GetAwaiter().GetResult();

--- a/GitHubRelease/Cli.cs
+++ b/GitHubRelease/Cli.cs
@@ -30,7 +30,7 @@ namespace GitHubRelease
         /// <summary>
         /// Gets or sets the repository name in the format userName/repoName.
         /// </summary>
-        [OptionalArgument("", "repo", "Specifies the Git repository in the format any of the following fortmats: \n" +
+        [OptionalArgument("", "repo", "Specifies the Git repository in the format any of the following formats: \n" +
             "\t repoName  (UserName is declared the `OWNER` environment variable) \n"+
             "\t userName/repoName\n" +
             "\t https://github.com/userName/repoName (Full URL to the repository on GitHub). This is applicable to all commands.")]
@@ -129,7 +129,7 @@ namespace GitHubRelease
 
             if (Command == CommandType.download && !Path.IsPathRooted(AssetPath))
             {
-                throw new ArgumentException("The 'path' option is required for the downloab commands and must be an absolute path.");
+                throw new ArgumentException("The 'path' option is required for the download commands and must be an absolute path.");
             }
 
 

--- a/GitHubRelease/Command.cs
+++ b/GitHubRelease/Command.cs
@@ -13,14 +13,14 @@ namespace GitHubRelease
         /// <param name="repo">The repository name.</param>
         /// <param name="tag">The tag name for the release.</param>
         /// <param name="branch">The branch name for the release.</param>
-        /// <param name="assetPath">The path to the asset to be included in the release.</param>
+        /// <param name="assetFileName">The path to the asset to be included in the release.</param>
         /// <returns>True if the release was created successfully, otherwise false.</returns>
         // <remarks>
         /// This method creates a new release in the specified repository using the provided tag, branch, and asset path.
         /// It utilizes the ReleaseService to interact with the GitHub API.
         /// If the release creation is successful, it returns true; otherwise, it logs the error and returns false.
         /// </remarks>
-        public static async Task<bool> CreateRelease(string repo, string tag, string branch, string assetPath)
+        public static async Task<bool> CreateRelease(string repo, string tag, string branch, string assetFileName)
         {
             var releaseService = new ReleaseService(repo);
 
@@ -35,7 +35,7 @@ namespace GitHubRelease
             };
 
             // Create a release
-            var responseMessage = await releaseService.CreateRelease(release, assetPath);
+            var responseMessage = await releaseService.CreateRelease(release, assetFileName);
             if (responseMessage.IsSuccessStatusCode)
             {
                 return true;
@@ -62,6 +62,20 @@ namespace GitHubRelease
         /// </remarks>/// 
         public static async Task<bool> DownloadAsset(string repo, string tag, string assetPath)
         {
+            // Check if we have write access to the assetPath
+            try
+            {
+                using FileStream fs = File.Create(assetPath, 1, FileOptions.DeleteOnClose);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                throw new UnauthorizedAccessException($"No write access to the path: {assetPath}");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"An error occurred while checking write access to the path: {assetPath}", ex);
+            }
+
             var releaseService = new ReleaseService(repo);
 
             // Ensure the assetPath includes a file name

--- a/GitHubRelease/Command.cs
+++ b/GitHubRelease/Command.cs
@@ -65,6 +65,11 @@ namespace GitHubRelease
             // Check if we have write access to the assetPath
             try
             {
+                // remove '\' from end of path if present
+                if (assetPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                {
+                    assetPath = assetPath.TrimEnd(Path.DirectorySeparatorChar);
+                }
                 using FileStream fs = File.Create(assetPath, 1, FileOptions.DeleteOnClose);
             }
             catch (UnauthorizedAccessException)

--- a/GitHubRelease/CommitService.cs
+++ b/GitHubRelease/CommitService.cs
@@ -49,7 +49,7 @@ namespace GitHubRelease
         /// <returns>The tag associated with the commit, or null if not found.</returns>
         private async Task<string?> GetTagFromCommitAsync(string commitSha)
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/tags";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/tags";
             
             var response = await ApiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
@@ -142,7 +142,7 @@ namespace GitHubRelease
                 else
                 {
                     var prNumber = prCommits[0].GetProperty("number").GetInt32().ToString();
-                    releaseNotes.AppendLine($"* {message} by @{author} in https://github.com/{Credentials.GetOwner()}/{Repo}/pull/{prNumber}");
+                    releaseNotes.AppendLine($"* {message} by @{author} in https://github.com/{Repo}/pull/{prNumber}");
                 }
             }
 
@@ -157,7 +157,7 @@ namespace GitHubRelease
 
         public async Task<List<JsonElement>> GetCommits(string? branch = null, string? sinceLastPublished = null)
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/commits";
             var queryParams = new List<string>();
             if (branch != null)
             {
@@ -204,7 +204,7 @@ namespace GitHubRelease
 
         public async Task<List<string>> GetReleaseTags(string? branch = null)
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/tags";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/tags";
             var response = await ApiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -219,10 +219,10 @@ namespace GitHubRelease
 
         public async Task<List<JsonElement>> GetPullRequestCommits(string? sha = null)
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/pulls";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/commits/pulls";
             if (sha != null)
             {
-                uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/{sha}/pulls";
+                uri = $"{Constants.GitHubApiPrefix}/{Repo}/commits/{sha}/pulls";
             }
 
             var response = await ApiService.GetAsync(uri);
@@ -237,7 +237,7 @@ namespace GitHubRelease
 
         private async Task<string> GetShaFromBranch(string branch)
         {
-            var branchUri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/branches/{branch}";
+            var branchUri = $"{Constants.GitHubApiPrefix}/{Repo}/branches/{branch}";
             var branchResponse = await ApiService.GetAsync(branchUri);
             if (branchResponse.IsSuccessStatusCode)
             {
@@ -286,6 +286,7 @@ namespace GitHubRelease
             return tagsList.ToArray();
         }
 
+ 
         private bool IsStageTag(string tag)
         {
             GitWrapper git = new();

--- a/GitHubRelease/ContributorService.cs
+++ b/GitHubRelease/ContributorService.cs
@@ -12,7 +12,7 @@ namespace GitHubRelease
         {
             var contributors = new List<string>();
 
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/contributors";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/contributors";
             var response = await apiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -43,7 +43,7 @@ namespace GitHubRelease
                     var author = commit.GetProperty("commit").GetProperty(AuthorPropertyName).GetProperty("name").GetString();
                     if (author != null && !contributors.Contains(author))
                     {
-                        var prUri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/{commit.GetProperty("sha").GetString()}/pulls";
+                        var prUri = $"{Constants.GitHubApiPrefix}/{Repo}/commits/{commit.GetProperty("sha").GetString()}/pulls";
                         var prResponse = await apiService.GetAsync(prUri);
                         if (prResponse.IsSuccessStatusCode)
                         {
@@ -52,7 +52,7 @@ namespace GitHubRelease
                             if (pulls.Any())
                             {
                                 var prNumber = pulls.ElementAt(0).GetProperty("number").GetString();
-                                releaseNotes.AppendLine($"* @{author} made their first contribution in https://github.com/{Credentials.GetOwner()}/{Repo}/pull/{prNumber}");
+                                releaseNotes.AppendLine($"* @{author} made their first contribution in https://github.com/{Repo}/pull/{prNumber}");
                             }
                         }
                     }

--- a/GitHubRelease/ContributorService.cs
+++ b/GitHubRelease/ContributorService.cs
@@ -13,7 +13,6 @@ namespace GitHubRelease
             var contributors = new List<string>();
 
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/contributors";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await apiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -45,7 +44,6 @@ namespace GitHubRelease
                     if (author != null && !contributors.Contains(author))
                     {
                         var prUri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/{commit.GetProperty("sha").GetString()}/pulls";
-                        Console.WriteLine($"GET uri: {prUri}");
                         var prResponse = await apiService.GetAsync(prUri);
                         if (prResponse.IsSuccessStatusCode)
                         {

--- a/GitHubRelease/Credentials.cs
+++ b/GitHubRelease/Credentials.cs
@@ -19,20 +19,8 @@ namespace GitHubRelease
         /// The owner is retrieved from the OWNER environment variable.
         /// The token is retrieved from the Windows Credential Manager if running on Windows, otherwise from the API_GITHUB_KEY environment variable.
         /// </remarks>
-        private static (SecureString owner, SecureString token) GetOwnerAndToken()
+        private static SecureString GetSecureToken()
         {
-            string? owner = Environment.GetEnvironmentVariable("OWNER");
-            if (owner == null)
-            {
-                throw new InvalidOperationException("Environment variable 'OWNER' is required");
-            }
-
-            SecureString secureOwner = CreateSecureString(owner);
-            if (secureOwner == null || secureOwner.Length == 0)
-            {
-                throw new ArgumentException("The OWNER environment variable cannot be empty");
-            }
-
             SecureString secureToken = GetTokenFromEnvironmentVariable();
 
             // If the token is not found in the environment variable and the OS is Windows, try to get it from the Credential Manager
@@ -46,10 +34,9 @@ namespace GitHubRelease
                 throw new InvalidOperationException("The API token could not be retrieved from the environment variable or the Credential Manager.");
             }
 
-            return (secureOwner, secureToken);
+            return secureToken;
         }
 
-        
         /// <summary>
         /// Saves a token to the Windows Credential Manager.
         /// </summary>
@@ -126,7 +113,8 @@ namespace GitHubRelease
         /// <returns>The GitHub repository owner.</returns>
         public static string GetOwner()
         {
-            return ConvertToUnsecureString(GetOwnerAndToken().owner);
+            string? owner = Environment.GetEnvironmentVariable("OWNER");
+            return owner ?? throw new InvalidOperationException("Environment variable 'OWNER' is required");
         }
 
         /// <summary>
@@ -135,7 +123,8 @@ namespace GitHubRelease
         /// <returns>The GitHub API token.</returns>
         public static string GetToken()
         {
-            return ConvertToUnsecureString(GetOwnerAndToken().token);
+
+            return ConvertToUnsecureString(GetSecureToken());
         }
 
 /// <summary>

--- a/GitHubRelease/Program.cs
+++ b/GitHubRelease/Program.cs
@@ -28,12 +28,6 @@ namespace GitHubRelease
                 Environment.Exit(1);
             }
 
-            // Print the command line values and exit
-            Console.WriteLine($"Repo: {options.Repo}");
-            Console.WriteLine($"Tag: {options.Tag}");
-            Console.WriteLine($"Branch: {options.Branch}");
-            Console.WriteLine($"Asset Path: {options.AssetPath}");
-
             bool result = false;
             try
             {

--- a/GitHubRelease/Program.cs
+++ b/GitHubRelease/Program.cs
@@ -37,32 +37,19 @@ namespace GitHubRelease
             bool result = false;
             try
             {
-                switch (options.Command)
+                result = options.Command switch
                 {
-                    // create a release
-                    case Cli.CommandType.create:
-                        result = await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!);
-                        break;
-
-                    // download an asset
-                    case Cli.CommandType.download:
-                        result = await Command.DownloadAsset(options.Repo!, options.Tag!, options.AssetPath!);
-                        break;
-
-                    default:
-
-                        Environment.Exit(1);
-                        break;
-                }
+                    Cli.CommandType.create => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!),
+                    Cli.CommandType.download => await Command.DownloadAsset(options.Repo!, options.Tag!, options.AssetPath!),
+                    _ => throw new InvalidOperationException("Invalid command")
+                };
             }
             catch (Exception ex)
             {
-                // log the type of exception Is it a NullReferenceException, ArgumentException, etc.
-                Console.WriteLine(ex.ToString());
-
                 // log exception
-                Console.WriteLine($"Exception {ex.Message}");
-                Environment.Exit(1);
+                Colorizer.WriteLine($"[{ConsoleColor.Red}!× " +
+                    $"'{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': Exception: {ex.Message}]");
+                Environment.Exit(-1);
             }
 
             Colorizer.WriteLine(result

--- a/GitHubRelease/Program.cs
+++ b/GitHubRelease/Program.cs
@@ -20,6 +20,9 @@ namespace GitHubRelease
             try
             {
                 options.Validate();
+
+                //Console.WriteLine("Debug: Validated CLI arguments successfully.");
+                //Environment.Exit(0);
             }
             catch (ArgumentException ex)
             {

--- a/GitHubRelease/ReleaseFormatter.cs
+++ b/GitHubRelease/ReleaseFormatter.cs
@@ -54,11 +54,11 @@ namespace GitHubRelease
             StringBuilder releaseNotes = new();
             if (string.IsNullOrEmpty(sinceTag))
             {
-                releaseNotes.AppendLine($"\n\n**Full Changelog**: https://github.com/{Credentials.GetOwner()}/{Repo}/commits/{tag}");
+                releaseNotes.AppendLine($"\n\n**Full Changelog**: https://github.com/{Repo}/commits/{tag}");
             }
             else
             {
-                releaseNotes.AppendLine($"\n\n**Full Changelog**: https://github.com/{Credentials.GetOwner()}/{Repo}/compare/{sinceTag}...{tag}");
+                releaseNotes.AppendLine($"\n\n**Full Changelog**: https://github.com/{Repo}/compare/{sinceTag}...{tag}");
             }
 
             return releaseNotes;

--- a/GitHubRelease/ReleaseService.cs
+++ b/GitHubRelease/ReleaseService.cs
@@ -84,7 +84,7 @@ namespace GitHubRelease
         /// <returns>The branch name if found; otherwise, <c>null</c>.</returns>
         private async Task<string?> GetBranchNameFromGitHubActions()
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/branches";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/branches";
             var response = await ApiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -129,7 +129,7 @@ namespace GitHubRelease
         /// <returns>The current commit SHA as a string, or an empty string if not found.</returns>
         private async Task<string> GetCurrentCommitSha()
         {
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/HEAD";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/commits/HEAD";
             var response = await ApiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -272,7 +272,7 @@ namespace GitHubRelease
             Console.WriteLine($"Release JSON Body: {jsonBody}");
 
             // Send a POST request to create a new release on GitHub
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases";
             var response = await ApiService.PostAsync(uri, new StringContent(jsonBody, Encoding.UTF8, "application/json"));
 
             if (!response.IsSuccessStatusCode)
@@ -342,7 +342,7 @@ namespace GitHubRelease
         public async Task<List<string>> GetReleaseTagsAsync()
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -395,7 +395,7 @@ namespace GitHubRelease
         public async Task<List<int>> GetReleaseIdsAsync()
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -424,7 +424,7 @@ namespace GitHubRelease
         private async Task<JsonDocument?> GetLatestReleaseRawAsync(string? branch = null)
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases";
             var response = await ApiService.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
@@ -530,7 +530,7 @@ namespace GitHubRelease
         public async Task<HttpResponseMessage> DeleteReleaseAsync(int releaseId)
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/{releaseId}";
             Console.WriteLine($"DELETE uri: {uri}");
             var response = await ApiService.DeleteAsync(uri);
 
@@ -556,7 +556,7 @@ namespace GitHubRelease
         {
             ApiService.SetupHeaders();
 
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/tags/{tagName}";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/tags/{tagName}";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -631,7 +631,7 @@ namespace GitHubRelease
         public async Task<Release?> GetReleaseAsync(int releaseId)
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/{releaseId}";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -700,7 +700,7 @@ namespace GitHubRelease
         public async Task<HttpResponseMessage> DownloadAsset(int assetId, string assetFileName)
         {
             ApiService.SetupHeaders();
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/assets/{assetId}";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/assets/{assetId}";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -741,7 +741,7 @@ namespace GitHubRelease
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
 
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}/assets";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/{releaseId}/assets";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -925,7 +925,7 @@ namespace GitHubRelease
                 return false;
             }
 
-            var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}/assets";
+            var uri = $"{Constants.GitHubApiPrefix}/{Repo}/releases/{releaseId}/assets";
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)

--- a/GitHubRelease/ReleaseService.cs
+++ b/GitHubRelease/ReleaseService.cs
@@ -57,6 +57,31 @@ namespace GitHubRelease
             return await CreateReleaseAndUploadAsset(release, assetPath);
         }
 
+        /// <summary>
+        /// Retrieves the branch name from GitHub Actions based on the current commit SHA.
+        /// </summary>
+        /// <remarks>
+        /// This method queries the GitHub API to fetch all branches of the repository and compares their commit SHAs
+        /// with the current commit SHA to determine the branch name. It is particularly useful in scenarios where
+        /// the repository is in a detached HEAD state, such as during GitHub Actions workflows.
+        /// 
+        /// - If a matching branch is found, its name is returned.
+        /// - If no matching branch is found, the method returns <c>null</c>.
+        /// 
+        /// Example usage:
+        /// <code>
+        /// var branchName = await GetBranchNameFromGitHubActions();
+        /// if (branchName != null)
+        /// {
+        ///     Console.WriteLine($"Branch name: {branchName}");
+        /// }
+        /// else
+        /// {
+        ///     Console.WriteLine("Branch name could not be determined.");
+        /// }
+        /// </code>
+        /// </remarks>
+        /// <returns>The branch name if found; otherwise, <c>null</c>.</returns>
         private async Task<string?> GetBranchNameFromGitHubActions()
         {
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/branches";
@@ -80,6 +105,28 @@ namespace GitHubRelease
             return null;
         }
 
+        /// <summary>
+        /// Retrieves the current commit SHA from the GitHub API.
+        /// </summary>
+        /// <remarks>
+        /// This method sends a GET request to the GitHub API to fetch the commit SHA of the HEAD reference.
+        /// - If the request is successful, the SHA is extracted from the response JSON and returned.
+        /// - If the request fails or the SHA is not found, an empty string is returned.
+        /// 
+        /// Example usage:
+        /// <code>
+        /// var commitSha = await GetCurrentCommitSha();
+        /// if (!string.IsNullOrEmpty(commitSha))
+        /// {
+        ///     Console.WriteLine($"Current Commit SHA: {commitSha}");
+        /// }
+        /// else
+        /// {
+        ///     Console.WriteLine("Failed to retrieve the commit SHA.");
+        /// }
+        /// </code>
+        /// </remarks>
+        /// <returns>The current commit SHA as a string, or an empty string if not found.</returns>
         private async Task<string> GetCurrentCommitSha()
         {
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/commits/HEAD";
@@ -323,6 +370,28 @@ namespace GitHubRelease
             }
         }
 
+        /// <summary>
+        /// Retrieves the IDs of all releases from the GitHub API.
+        /// </summary>
+        /// <remarks>
+        /// This method sends a GET request to the GitHub API to fetch all releases for the specified repository.
+        /// - If the request is successful, it parses the response JSON to extract the release IDs and returns them as a list.
+        /// - If the request fails, it logs the error details and returns an empty list.
+        /// 
+        /// Example usage:
+        /// <code>
+        /// var releaseIds = await GetReleaseIdsAsync();
+        /// if (releaseIds.Any())
+        /// {
+        ///     Console.WriteLine($"Found {releaseIds.Count} releases.");
+        /// }
+        /// else
+        /// {
+        ///     Console.WriteLine("No releases found.");
+        /// }
+        /// </code>
+        /// </remarks>
+        /// <returns>A list of release IDs.</returns>
         public async Task<List<int>> GetReleaseIdsAsync()
         {
             ApiService.SetupHeaders();
@@ -488,7 +557,6 @@ namespace GitHubRelease
             ApiService.SetupHeaders();
 
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/tags/{tagName}";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -564,7 +632,6 @@ namespace GitHubRelease
         {
             ApiService.SetupHeaders();
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -634,7 +701,6 @@ namespace GitHubRelease
         {
             ApiService.SetupHeaders();
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/assets/{assetId}";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -652,6 +718,20 @@ namespace GitHubRelease
             return response;
         }
 
+
+        /// <summary>
+        /// Downloads an asset by its name from a specific release tag.
+        /// </summary>
+        /// <param name="tagName">The tag name of the release.</param>
+        /// <param name="assetName">The name of the asset to download.</param>
+        /// <param name="downloadPath">The path where the asset will be downloaded.</param>
+        /// <returns>The HTTP response message from the download operation.</returns>
+        /// <remarks>
+        /// This method retrieves the release ID associated with the specified tag name and fetches the list of assets for that release.
+        /// It then searches for the asset by its name and downloads it to the specified path.
+        /// If the release or asset is not found, an appropriate HTTP response with a status code of <see cref="HttpStatusCode.NotFound"/> is returned.
+
+        ////// </remarks>
         public async Task<HttpResponseMessage> DownloadAssetByName(string tagName, string assetName, string downloadPath)
         {
             var releaseId = await GetReleaseByTagNameAsync(tagName);
@@ -662,7 +742,6 @@ namespace GitHubRelease
             }
 
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}/assets";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)
@@ -673,7 +752,8 @@ namespace GitHubRelease
 
                 if (asset.ValueKind != JsonValueKind.Undefined)
                 {
-                    var downloadUrl = asset.GetProperty("browser_download_url").GetString();
+                    // Use "url" property to get the download URL.  This allows download of private a
+                    var downloadUrl = asset.GetProperty("url").GetString();
                     if (!string.IsNullOrEmpty(downloadUrl))
                     {
                         // Build full filename with path
@@ -792,89 +872,48 @@ namespace GitHubRelease
         }
 
 
+        /// <summary>
+        /// Downloads an asset from a specified URL and saves it to a file.
+        /// </summary>
+        /// <param name="downloadUrl">The URL of the asset to download.</param>
+        /// <param name="assetFileName">The full path where the asset will be saved.</param>
+        /// <returns>The HTTP response message from the download operation.</returns>
+        /// <remarks>
+        /// This method uses the <see cref="ApiService"/> to set up headers and perform the download operation.
+        /// If the download is successful, the asset is saved to the specified file path.
+        /// For larger files, consider using a streaming approach to avoid memory issues.
+        /// for larger than 10 mb files, use the following code:
+        /// using (var contentStream = await response.Content.ReadAsStreamAsync())
+        /// using (var fileStream = System.IO.File.Create(assetFileName))
+        /// {
+        ///     await contentStream.CopyToAsync(fileStream);
+        /// }
+        /// </remarks>
         public async Task<HttpResponseMessage> DownloadAssetFromUrl(string downloadUrl, string assetFileName)
         {
             ApiService.SetupHeaders(download: true);
-
-            // Log the headers
-            //Console.WriteLine("Request Headers:");
-            //foreach (var header in ApiService.GetClient().DefaultRequestHeaders)
-            //{
-            //    Console.WriteLine($"{header.Key}: {string.Join(", ", header.Value)}");
-            //}
-
-            Console.WriteLine($"GET uri: {downloadUrl}");
-            var response = await ApiService.GetAsync(downloadUrl);
+            
+            var response = await ApiService.GetClient().GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
 
             if (response.IsSuccessStatusCode)
             {
-                var assetContent = await response.Content.ReadAsByteArrayAsync();
-
-                // Write size of content to console
-                Console.WriteLine($"Size of downloaded content: {assetContent.Length} bytes");
-
-                await File.WriteAllBytesAsync(assetFileName, assetContent);
-                Console.WriteLine($"Successfully downloaded the asset to: {assetFileName}");
+                try
+                {
+                    var assetContent = await response.Content.ReadAsByteArrayAsync();
+                    await File.WriteAllBytesAsync(assetFileName, assetContent);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"An error occurred while downloading the asset from URL: {downloadUrl}. Exception: {ex.Message}", ex);
+                }
             }
             else
             {
                 Console.WriteLine($"Error: Could not download the asset. Status code: {response.StatusCode}");
-                var responseContent = await response.Content.ReadAsStringAsync();
-                Console.WriteLine($"Response content: {responseContent}");
             }
 
             return response;
         }
-
-
-        //public async Task<HttpResponseMessage> DownloadAssetFromUrl(string downloadUrl, string assetFileName)
-        //{
-        //    ApiService.SetupHeaders(download: true);
-
-        //    // Log the Authorization header
-        //    //var authorizationHeader = ApiService.GetClient().DefaultRequestHeaders.Authorization;
-        //    //if (authorizationHeader == null)
-        //    //{
-        //    //    Console.WriteLine("Authorization header is not set.");
-        //    //    throw new InvalidOperationException("Authorization header is not set.");
-        //    //}
-        //    //else
-        //    //{
-        //    //    Console.WriteLine($"Authorization: {authorizationHeader.Scheme} {authorizationHeader.Parameter}");
-
-        //    //    await CheckTokenPermissions();
-        //    //}
-
-        //    //ApiService.SetupHeaders(download: true);
-
-        //    // Log the headers
-        //    //foreach (var header in ApiService.GetClient().DefaultRequestHeaders)
-        //    //{
-        //    //    Console.WriteLine($"{header.Key}: {string.Join(", ", header.Value)}");
-        //    //}
-
-        //    Console.WriteLine($"GET uri: {downloadUrl}");
-        //    var response = await ApiService.GetAsync(downloadUrl);
-
-        //    if (response.IsSuccessStatusCode)
-        //    {
-        //        var assetContent = await response.Content.ReadAsByteArrayAsync();
-
-        //        // Write size of content to console
-        //        Console.WriteLine($"Size of downloaded content: {assetContent.Length} bytes");
-
-        //        await File.WriteAllBytesAsync(assetFileName, assetContent);
-        //        Console.WriteLine($"Successfully downloaded the asset to: {assetFileName}");
-        //    }
-        //    else
-        //    {
-        //        Console.WriteLine($"Error: Could not download the asset. Status code: {response.StatusCode}");
-        //        var responseContent = await response.Content.ReadAsStringAsync();
-        //        Console.WriteLine($"Response content: {responseContent}");
-        //    }
-
-        //    return response;
-        //}
 
 
         public async Task<bool> VerifyAssetId(string tagName, int assetId)
@@ -887,7 +926,6 @@ namespace GitHubRelease
             }
 
             var uri = $"{Constants.GitHubApiPrefix}/{Credentials.GetOwner()}/{Repo}/releases/{releaseId}/assets";
-            Console.WriteLine($"GET uri: {uri}");
             var response = await ApiService.GetAsync(uri);
 
             if (response.IsSuccessStatusCode)

--- a/GitHubReleaseTests/CliTests.cs
+++ b/GitHubReleaseTests/CliTests.cs
@@ -1,13 +1,113 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.IO;
-using System.Threading.Tasks;
-
 namespace GitHubRelease.Tests
 {
     [TestClass]
     public class CliTests
     {
+        [TestMethod]
+        public async Task ValidateRepo_ShouldExtractUserNameAndRepoName_FromFullUrl()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Repo = "https://github.com/naz-hage/ntools"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+
+            // Assert
+            Assert.AreEqual("naz-hage/ntools", cli.Repo, "The Repo property should correctly extract userName/repoName from the full URL.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ValidateRepo_ShouldThrowException_ForNonGitHubDomain()
+        {
+            // Arrange
+            var cli = new GitHubRelease.Cli
+            {
+                Repo = "https://gitlab.com/userName/repoName"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+
+            // Assert
+            // Exception is expected
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ValidateRepo_ShouldThrowException_ForInvalidRepoFormat()
+        {
+            // Arrange
+            var cli = new GitHubRelease.Cli
+            {
+                Repo = "invalid/repo/format"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+
+            // Assert
+            // Exception is expected
+        }
+
+        [TestMethod]
+        public async Task ValidateRepo_ShouldHandleRepoNameOnly_WithOwnerEnvironmentVariable()
+        {
+            // Save current "OWNER" environment Variable
+            var owner = Environment.GetEnvironmentVariable("OWNER");
+
+            // Arrange
+            Environment.SetEnvironmentVariable("OWNER", "naz-hage");
+            var cli = new GitHubRelease.Cli
+            {
+                Repo = "ntools"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+
+            // Assert
+            Assert.AreEqual("naz-hage/ntools", cli.Repo, "The Repo property should correctly combine OWNER and repoName.");
+
+            // restore current "OWNER" env. variable
+            Environment.SetEnvironmentVariable("OWNER", owner);
+
+            // Assert
+            Assert.AreEqual(owner, Environment.GetEnvironmentVariable("OWNER"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task ValidateRepo_ShouldThrowException_WhenOwnerEnvironmentVariableIsMissing()
+        {
+            // Save current "OWNER" environment Variable
+            var owner = Environment.GetEnvironmentVariable("OWNER");
+
+            // Arrange
+            Environment.SetEnvironmentVariable("OWNER", null);
+            var cli = new GitHubRelease.Cli
+            {
+                Repo = "ntools"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+
+            // Expect exception
+
+            // Assert
+            Assert.AreEqual("naz-hage/ntools", cli.Repo, "The Repo property should correctly combine OWNER and repoName.");
+
+            // restore current "OWNER" env. variable
+            Environment.SetEnvironmentVariable("OWNER", owner);
+
+            // Assert
+            Assert.AreEqual(owner, Environment.GetEnvironmentVariable("OWNER"));
+        }
+
         [TestMethod]
         public void GetCommandType_ValidCommand_ShouldReturnCorrectCommandType()
         {

--- a/GitHubReleaseTests/CliTests.cs
+++ b/GitHubReleaseTests/CliTests.cs
@@ -83,6 +83,13 @@ namespace GitHubRelease.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public async Task ValidateRepo_ShouldThrowException_WhenOwnerEnvironmentVariableIsMissing()
         {
+            // Skip this test if running in GitHub Actions
+            if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
+            {
+                Assert.Inconclusive("Skipping test in GitHub Actions environment.");
+                return;
+            }
+
             // Save current "OWNER" environment Variable
             var owner = Environment.GetEnvironmentVariable("OWNER");
 

--- a/GitHubReleaseTests/CliTests.cs
+++ b/GitHubReleaseTests/CliTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GitHubRelease.Tests
+{
+    [TestClass]
+    public class CliTests
+    {
+        [TestMethod]
+        public void GetCommandType_ValidCommand_ShouldReturnCorrectCommandType()
+        {
+            // Arrange
+            var cli = new Cli { Command = Cli.CommandType.create };
+
+            // Act
+            var commandType = cli.GetCommandType();
+
+            // Assert
+            Assert.AreEqual(Cli.CommandType.create, commandType);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetCommandType_InvalidCommand_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli();
+            cli.Command = (Cli.CommandType)999; // Invalid command
+
+            // Act
+            cli.GetCommandType();
+        }
+
+        [TestMethod]
+        public void Validate_ValidArguments_ShouldPass()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Command = Cli.CommandType.create,
+                Repo = "naz-hage/ntools",
+                Tag = "1.0.0",
+                Branch = "main",
+                AssetFileName = "file.zip"
+            };
+
+            // Act & Assert
+            cli.Validate();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Validate_MissingRepo_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Command = Cli.CommandType.create,
+                Tag = "v1.0.0",
+                Branch = "main",
+                AssetFileName = "file.zip"
+            };
+
+            // Act
+            cli.Validate();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Validate_InvalidRepoFormat_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Command = Cli.CommandType.create,
+                Repo = "invalidRepoFormat",
+                Tag = "v1.0.0",
+                Branch = "main",
+                AssetFileName = "file.zip"
+            };
+
+            // Act
+            cli.Validate();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Validate_MissingTag_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Command = Cli.CommandType.create,
+                Repo = "user/repo",
+                Branch = "main",
+                AssetFileName = "file.zip"
+            };
+
+            // Act
+            cli.Validate();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Validate_MissingFileForCreateCommand_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli
+            {
+                Command = Cli.CommandType.create,
+                Repo = "user/repo",
+                Tag = "v1.0.0",
+                Branch = "main"
+            };
+
+            // Act
+            cli.Validate();
+        }
+
+        [TestMethod]
+        public async Task ValidateRepo_ValidRepo_ShouldPass()
+        {
+            // Arrange
+            var cli = new Cli() 
+            {
+                Repo = "naz-hage/ntools"
+            };
+
+            // Act & Assert
+            await cli.ValidateRepo();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ValidateRepo_InvalidRepo_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli()
+            {
+                Repo = "invalid/repo"
+            };
+
+            // Act
+            await cli.ValidateRepo();
+        }
+
+        [TestMethod]
+        public async Task ValidateRepositoryExists_ValidRepo_ShouldPass()
+        {
+            // Arrange
+            // Arrange
+            var cli = new Cli()
+            {
+                Repo = "naz-hage/ntools"
+            };
+
+            // Act & Assert
+            await cli.ValidateRepositoryExists();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ValidateRepositoryExists_InvalidRepo_ShouldThrowException()
+        {
+            // Arrange
+            var cli = new Cli()
+            {
+                Repo = "invalid/repo"
+            };
+
+            // Act
+            await cli.ValidateRepositoryExists();
+        }
+    }
+}

--- a/GitHubReleaseTests/GitHubSetup.cs
+++ b/GitHubReleaseTests/GitHubSetup.cs
@@ -5,7 +5,7 @@ namespace GitHubRelease.Tests
 {
     public class GitHubSetup
     {
-        protected readonly string Repo = "learn"; //"ntools";//"learn";
+        protected readonly string Repo = "naz-hage/learn";
 
         protected readonly string MainBranch = "main";
         protected readonly string DefaultBranch = "main";//"58-issue";// "13-issue";

--- a/GitHubReleaseTests/ReleaseServiceTests.cs
+++ b/GitHubReleaseTests/ReleaseServiceTests.cs
@@ -240,8 +240,8 @@ namespace GitHubRelease.Tests
             Console.WriteLine($"repo: {repo}");
             Console.WriteLine($"tagName: {tagName}");
             Console.WriteLine($"assetName: {assetName}");
-            Console.WriteLine($"DownloadPath: {{DownloadPath}}");
-            Console.WriteLine($"assetFileName: {{assetFileName}}");
+            Console.WriteLine($"DownloadPath: {DownloadPath}");
+            Console.WriteLine($"assetFileName: {assetFileName}");
 
 
 

--- a/GitHubReleaseTests/ReleaseServiceTests.cs
+++ b/GitHubReleaseTests/ReleaseServiceTests.cs
@@ -234,6 +234,16 @@ namespace GitHubRelease.Tests
             string assetName = $"{tagName}.zip";
             string DownloadPath = @"c:\temp";
             var assetFileName = Path.Combine(DownloadPath, assetName);
+            var repo = "naz-hage/ntools";
+
+            // write parameters to console
+            Console.WriteLine($"repo: {repo}");
+            Console.WriteLine($"tagName: {tagName}");
+            Console.WriteLine($"assetName: {assetName}");
+            Console.WriteLine($"DownloadPath: {{DownloadPath}}");
+            Console.WriteLine($"assetFileName: {{assetFileName}}");
+
+
 
             // Delete the file if it exists
             if (File.Exists(assetFileName))
@@ -241,7 +251,7 @@ namespace GitHubRelease.Tests
                 File.Delete(assetFileName);
             }
 
-            var releaseService = new ReleaseService("ntools");
+            var releaseService = new ReleaseService(repo);
 
             // Act
             var response = await releaseService.DownloadAssetByName(tagName, assetName, DownloadPath);

--- a/GitHubReleaseTests/ReleaseServiceTests.cs
+++ b/GitHubReleaseTests/ReleaseServiceTests.cs
@@ -48,12 +48,12 @@ namespace GitHubRelease.Tests
             Assert.AreEqual(result.StatusCode.ToString(), "Created");
 
             // Skip Private repo Download the asset
-            //var assetName = $"{TagStagingRequested}.zip";
-            //string DownloadPath = @"c:\temp";
-            //var response = await releaseService.DownloadAssetByName(release.TagName, assetName, DownloadPath);
+            var assetName = $"{TagStagingRequested}.zip";
+            string DownloadPath = @"c:\temp";
+            var response = await releaseService.DownloadAssetByName(release.TagName, assetName, DownloadPath);
 
-            //// Assert
-            //Assert.IsTrue(response.IsSuccessStatusCode, $"Failed to download the asset.  status: {response.StatusCode}.");
+            // Assert
+            Assert.IsTrue(response.IsSuccessStatusCode, $"Failed to download the asset.  status: {response.StatusCode}.");
 
         }
 
@@ -185,46 +185,46 @@ namespace GitHubRelease.Tests
             }
         }
 
-        // [TestMethod]
-        // public async Task DownloadPrivateAssetByName_ShouldDownloadAsset()
-        // {
-        //     // Skip the test if running in GitHub Actions
-        //     if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null)
-        //     {
-        //         Assert.Inconclusive();
-        //     }
+        [TestMethod]
+        public async Task DownloadPrivateAssetByName_ShouldDownloadAsset()
+        {
+            // Skip the test if running in GitHub Actions
+            if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null)
+            {
+                Assert.Inconclusive();
+            }
 
-        //     // Arrange
-        //     string tagName = "1.2.1";
-        //     string assetName = $"{tagName}.zip";
-        //     string DownloadPath = @"c:\temp";
-        //     var assetFileName = Path.Combine(DownloadPath, assetName);
-        //     //string owner = "naz-hage";
-        //     //var downloadUrl = $"https://github.com/{owner}/{Repo}/releases/download/{tagName}/{assetName}";
+            // Arrange
+            string tagName = "1.2.1";
+            string assetName = $"{tagName}.zip";
+            string DownloadPath = @"c:\temp";
+            var assetFileName = Path.Combine(DownloadPath, assetName);
+            //string owner = "naz-hage";
+            //var downloadUrl = $"https://github.com/{owner}/{Repo}/releases/download/{tagName}/{assetName}";
 
-        //     // Delete the file if it exists
-        //     if (File.Exists(assetFileName))
-        //     {
-        //         File.Delete(assetFileName);
-        //     }
+            // Delete the file if it exists
+            if (File.Exists(assetFileName))
+            {
+                File.Delete(assetFileName);
+            }
 
-        //     var releaseService = new ReleaseService(Repo);
+            var releaseService = new ReleaseService(Repo);
 
-        //     // Act
-        //     var response = await releaseService.DownloadAssetByName(tagName, assetName, DownloadPath);
-        //     //var response = await releaseService.DownloadAssetFromUrl(downloadUrl, assetFileName);
+            // Act
+            var response = await releaseService.DownloadAssetByName(tagName, assetName, DownloadPath);
+            //var response = await releaseService.DownloadAssetFromUrl(downloadUrl, assetFileName);
 
-        //     // Assert
-        //     Assert.IsTrue(response.IsSuccessStatusCode, $"Failed to download the asset.  status: {response.StatusCode}.");
-            
-        //     Assert.IsTrue(File.Exists(assetFileName), "The asset file was not downloaded.");
+            // Assert
+            Assert.IsTrue(response.IsSuccessStatusCode, $"Failed to download the asset.  status: {response.StatusCode}.");
 
-        //     // Clean up
-        //     if (File.Exists(assetFileName))
-        //     {
-        //         File.Delete(assetFileName);
-        //     }
-        // }
+            Assert.IsTrue(File.Exists(assetFileName), "The asset file was not downloaded.");
+
+            // Clean up
+            if (File.Exists(assetFileName))
+            {
+                File.Delete(assetFileName);
+            }
+        }
 
         [TestMethod]
         public async Task DownloadPublicAssetByName_ShouldDownloadAsset()

--- a/GitHubReleaseTests/ReleaseServiceTests.cs
+++ b/GitHubReleaseTests/ReleaseServiceTests.cs
@@ -230,7 +230,7 @@ namespace GitHubRelease.Tests
         public async Task DownloadPublicAssetByName_ShouldDownloadAsset()
         {
             // Arrange
-            string tagName = "1.12.6";
+            string tagName = "1.13.0";
             string assetName = $"{tagName}.zip";
             string DownloadPath = @"c:\temp";
             var assetFileName = Path.Combine(DownloadPath, assetName);

--- a/dev-setup/ntools.json
+++ b/dev-setup/ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.12.0",
+      "Version": "1.13.0",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -90,7 +90,7 @@ GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file valu
          download        -> Download an asset. Requires repo, tag, and path (optional)
          ----
  (one of create,download, required)
-  - repo    : Specifies the Git repository in the format any of the following fortmats:
+  - repo    : Specifies the Git repository in the format any of the following formats:
          repoName  (UserName is declared the `OWNER` environment variable)
          userName/repoName
          https://github.com/userName/repoName (Full URL to the repository on GitHub). This is applicable to all commands. (string, default=)

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -113,6 +113,6 @@ GitHubRelease.exe download -repo my-repo -tag 1.0.0 -path C:\Downloads -v true
 An asset named 1.0.0.zip will be downloaded to the specified path if it exists in the release.
 
 
--- Current expections:
+-- Current expectations:
 - The download assets expects to download an asset as a zip file name ${tag}.zip
 - tag must be a valid tag in the repository created by the tool. (X.Y.Z)

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -111,3 +111,8 @@ To download an asset from the release with the tag `1.0.0` in the repository `my
 GitHubRelease.exe download -repo my-repo -tag 1.0.0 -path C:\Downloads -v true
 ```
 An asset named 1.0.0.zip will be downloaded to the specified path if it exists in the release.
+
+
+-- Current expections:
+- The download assets expects to download an asset as a zip file name ${tag}.zip
+- tag must be a valid tag in the repository created by the tool. (X.Y.Z)

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -1,6 +1,4 @@
-# GitHubRelease Documentation
-
-GitHubRelease is a tool that allows you to create and manage GitHub releases from the command line. It simplifies the process of creating and managing releases, making it easier to publish your software updates on GitHub.
+GitHubRelease is a command-line tool designed to help you create and manage GitHub releases. It also enables you to download release assets, such as files named in the format x.y.z.zip. The tool expects downloaded assets to be in a zip file named ${tag}.zip, where tag must be a valid tag in the repository created by the tool (e.g., ``x.y.z``).  checkout the [tagging](../versioning.md) section for more details.
 
 ## Requirements
 
@@ -34,6 +32,7 @@ Here is an example of how to set up the required environment variables in a GitH
     OWNER: ${{ github.repository_owner }}
     API_GITHUB_KEY: ${{ secrets.API_GITHUB_KEY }}
 ```
+The above action builds, test, and creates a release using the GitHubRelease tool and upload to GitHub.
 
 ### Branch Checkout Example
 Before running the tool, you must checkout a branch. Here is an example of how to checkout a branch in a GitHub Actions workflow file:
@@ -91,7 +90,10 @@ GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file valu
          download        -> Download an asset. Requires repo, tag, and path (optional)
          ----
  (one of create,download, required)
-  - repo    : Specifies the Git repository in the format userName/repoName. Applicable to all commands. (string, default=)
+  - repo    : Specifies the Git repository in the format any of the following fortmats:
+         repoName  (UserName is declared the `OWNER` environment variable)
+         userName/repoName
+         https://github.com/userName/repoName (Full URL to the repository on GitHub). This is applicable to all commands. (string, default=)
   - tag     : Specifies the tag name. Applicable for all commands (string, default=)
   - branch  : Specifies the branch name. Applicable for create command (string, default=main)
   - file    : Specifies the asset file name. Must include full path. Applicable for create command (string, default=)
@@ -102,18 +104,30 @@ GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file valu
 To create a release for the repository `my-repo` with the tag `1.0.0`, branch `main`, and an asset located at `C:\Releases\1.0.0.zip`, you would use the following command:
 
 ```batch
-GitHubRelease.exe create -repo userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip -v true
+GitHubRelease.exe create -repo userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip
 ```
 
 ### Example: Downloading an Asset
 To download an asset from the release with the tag `1.0.0` in the repository `my-repo` to the path `C:\Downloads`:
 
 ```batch
-GitHubRelease.exe download -repo userName/my-repo -tag 1.0.0 -path C:\Downloads -v true
+GitHubRelease.exe download -repo userName/my-repo -tag 1.0.0 -path C:\Downloads
 ```
 An asset named 1.0.0.zip will be downloaded to the specified path if it exists in the release.
 
+Here is the updated section in github-release.md with an example using the `-repo` option with a full GitHub URL:
 
-## Current expectations:
-- The download assets expects to download an asset as a zip file name ${tag}.zip
-- `tag` must be a valid tag in the repository created by the tool. (X.Y.Z)
+### Example: Creating a Release with Full GitHub URL
+To create a release for the repository `my-repo` with the tag `1.0.0`, branch `main`, and an asset located at `C:\Releases\1.0.0.zip`, using the full GitHub URL:
+
+```batch
+GitHubRelease.exe create -repo https://github.com/userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.0.0.zip
+```
+
+### Example: Downloading an Asset with Full GitHub URL
+To download an asset from the release with the tag `1.0.0` in the repository `my-repo` to the path `C:\Downloads`, using the full GitHub URL:
+
+```batch
+GitHubRelease.exe download -repo https://github.com/userName/my-repo -tag 1.0.0 -path C:\Downloads
+```
+An asset named `1.0.0.zip` will be downloaded to the specified path if it exists in the release.

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -12,8 +12,9 @@ GitHubRelease is a tool that allows you to create and manage GitHub releases fro
   - At least one Git tag prior to creating releases.
 
 ### Environment Requirements
-- The GitHub API token and repository owner are obtained from environment variables:
+- The GitHub API token (Required) and repository owner (Optional) are obtained from environment variables:
   - **`OWNER`:** The GitHub repository owner's username.
+    - The owner is optional and can be specified in the command line with `-repo` option. Checkout usage below.
   - **`API_GITHUB_KEY`:** The GitHub API token (personal access token).
 - **Local development with Windows Platforms:**
   - For additional security, the GitHub API token should be saved in the Windows Credential Manager with:
@@ -90,8 +91,8 @@ GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file valu
          download        -> Download an asset. Requires repo, tag, and path (optional)
          ----
  (one of create,download, required)
-  - repo    : Specifies the repository name. Applicable to all commands. (string, default=)
-  - tag     : Specifies the tag name. Aplicable for all commands (string, default=)
+  - repo    : Specifies the Git repository in the format userName/repoName. Applicable to all commands. (string, default=)
+  - tag     : Specifies the tag name. Applicable for all commands (string, default=)
   - branch  : Specifies the branch name. Applicable for create command (string, default=main)
   - file    : Specifies the asset file name. Must include full path. Applicable for create command (string, default=)
   - path    : Specifies the asset path. Must be an absolute path. (string, default=)
@@ -101,18 +102,18 @@ GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file valu
 To create a release for the repository `my-repo` with the tag `1.0.0`, branch `main`, and an asset located at `C:\Releases\1.0.0.zip`, you would use the following command:
 
 ```batch
-GitHubRelease.exe create -repo my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip -v true
+GitHubRelease.exe create -repo userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip -v true
 ```
 
 ### Example: Downloading an Asset
 To download an asset from the release with the tag `1.0.0` in the repository `my-repo` to the path `C:\Downloads`:
 
 ```batch
-GitHubRelease.exe download -repo my-repo -tag 1.0.0 -path C:\Downloads -v true
+GitHubRelease.exe download -repo userName/my-repo -tag 1.0.0 -path C:\Downloads -v true
 ```
 An asset named 1.0.0.zip will be downloaded to the specified path if it exists in the release.
 
 
--- Current expectations:
+## Current expectations:
 - The download assets expects to download an asset as a zip file name ${tag}.zip
-- tag must be a valid tag in the repository created by the tool. (X.Y.Z)
+- `tag` must be a valid tag in the repository created by the tool. (X.Y.Z)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -12,3 +12,9 @@ Throughout this document, the terms "version" and "tag" are used interchangeably
       - Incrementing `Y` resets `Z` to 0.
     - `Z` is the build number:
         - Incremented when [staging](buildtypes.md#staging) Build Type is deployed.
+
+Tags in the [GitHubRelease](./ntools/github-release.md) are used to:
+
+- Identify specific versions of the repository.
+- Associate release assets with a particular version.
+- Generate release notes based on commits since the last tag.


### PR DESCRIPTION
#90 
### Comments from @ahmdhjj PR #89

- [x] Ensure the user provides the full repo URL or username/repo instead of changing the environment variable per project:
  - Update the -repo command line option
  - repo    : Specifies the Git repository in the format any of the following fortmats:
         repoName  (UserName is declared the `OWNER` environment variable)
         userName/repoName
         https://github.com/userName/repoName (Full URL to the repository on GitHub).

- [x] Fix or remove commented-out tests.

- [x] Correctly handle the `-path c:\temp\` to form the full file name for downloads.
