### PR TITLE
Add git_info command and update Ntools version

### DIFF
--- a/Nbuild/Cli.cs
+++ b/Nbuild/Cli.cs
@@ -32,7 +32,7 @@ public class Cli
         "\t download \t -> Downloads apps specified in the -json option (require admin privileges to run).\n" +
         "\t targets \t -> Lists available targets and saves them in the targets.md file.\n" +
         "\t path \t\t -> Displays environment path in local machine.\n" +
-        "\t git_info\t -> Displays the current git inforamation in the local repository.\n" +
+        "\t git_info\t -> Displays the current git information in the local repository.\n" +
         "\t ----\n")]
     public CommandType Command { get; set; }
 

--- a/Nbuild/Cli.cs
+++ b/Nbuild/Cli.cs
@@ -18,7 +18,7 @@ public class Cli
         download,
         targets,
         path,
-        git_tag
+        git_info
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public class Cli
         "\t download \t -> Downloads apps specified in the -json option (require admin privileges to run).\n" +
         "\t targets \t -> Lists available targets and saves them in the targets.md file.\n" +
         "\t path \t\t -> Displays environment path in local machine.\n" +
-        "\t git_tag\t -> Display current git tag" +
+        "\t git_info\t -> Displays the current git inforamation in the local repository.\n" +
         "\t ----\n")]
     public CommandType Command { get; set; }
 

--- a/Nbuild/Cli.cs
+++ b/Nbuild/Cli.cs
@@ -17,7 +17,8 @@ public class Cli
         uninstall,
         download,
         targets,
-        path
+        path,
+        git_tag
     }
 
     /// <summary>
@@ -31,6 +32,7 @@ public class Cli
         "\t download \t -> Downloads apps specified in the -json option (require admin privileges to run).\n" +
         "\t targets \t -> Lists available targets and saves them in the targets.md file.\n" +
         "\t path \t\t -> Displays environment path in local machine.\n" +
+        "\t git_tag\t -> Display current git tag" +
         "\t ----\n")]
     public CommandType Command { get; set; }
 

--- a/Nbuild/Command.cs
+++ b/Nbuild/Command.cs
@@ -892,7 +892,7 @@ namespace Nbuild
             var resultHelper = process.LockStart(verbose);
             if (!resultHelper.IsSuccess())
             {
-                if (verbose) Console.WriteLine($"==> Failed to display git info:{resultHelper.GetFirstOutput()}");
+                if (verbose) Console.WriteLine($"==> Failed to display git info: {resultHelper.GetFirstOutput()}");
             }
 
             return resultHelper;

--- a/Nbuild/Command.cs
+++ b/Nbuild/Command.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using static NbuildTasks.Enums;
 
 namespace Nbuild
 {

--- a/Nbuild/Command.cs
+++ b/Nbuild/Command.cs
@@ -864,38 +864,20 @@ namespace Nbuild
         /// <summary>
         /// Displays git information if git is configured and folder is git repository.
         /// </summary>
-        /// <param name="verbose">Flag indicating whether to display verbose output.</param>
-        public static ResultHelper DisplayGitInfo(bool verbose = false)
+        public static ResultHelper DisplayGitInfo()
         {
-            const string NgitAssemblyExe = "ngit.exe";
-    
-            GitWrapper gitWrapper = new(project: null, verbose: verbose);
-            if (!gitWrapper.IsGitConfigured(silent: true) || !gitWrapper.IsGitRepository(Environment.CurrentDirectory)) return ResultHelper.Fail(-1, "folder is not git repo");
-
-
-            // Get the directory of the current process
-            var executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
-            var process = new Process
+            var project = Path.GetFileName(Directory.GetCurrentDirectory());
+            var gitWrapper= new GitWrapper();
+            if (string.IsNullOrEmpty(gitWrapper.Branch))
             {
-                StartInfo =
-            {
-                WorkingDirectory = Environment.CurrentDirectory,
-                FileName = Path.Combine(executableDirectory!, NgitAssemblyExe),
-                Arguments = $"branch",
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
-                UseShellExecute = false,
-            },
-            };
-
-            var resultHelper = process.LockStart(verbose);
-            if (!resultHelper.IsSuccess())
-            {
-                if (verbose) Console.WriteLine($"==> Failed to display git info: {resultHelper.GetFirstOutput()}");
+                Colorizer.WriteLine($"[{ConsoleColor.Red}!Error: [{ConsoleColor.Yellow}!{project}] directory is not a git repository]");
+                Parser.DisplayHelp<Cli>(HelpFormat.Full);
+                return ResultHelper.Fail(-1, "Not a git repository");
             }
-
-            return resultHelper;
+            Colorizer.WriteLine($"[{ConsoleColor.DarkMagenta}!Project [{ConsoleColor.Yellow}!{project}] " +
+                                                    $"Branch [{ConsoleColor.Yellow}!{gitWrapper.Branch}] " +
+                                                    $"Tag [{ConsoleColor.Yellow}!{gitWrapper.Tag}]]");
+            return ResultHelper.Success();
         }
     }
 }

--- a/Nbuild/Command.cs
+++ b/Nbuild/Command.cs
@@ -865,7 +865,7 @@ namespace Nbuild
         /// Displays git information if git is configured and folder is git repository.
         /// </summary>
         /// <param name="verbose">Flag indicating whether to display verbose output.</param>
-        public static ResultHelper DisplayGitInfo(bool verbose)
+        public static ResultHelper DisplayGitInfo(bool verbose = false)
         {
             const string NgitAssemblyExe = "ngit.exe";
     

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -80,8 +80,9 @@ public class Program
             Environment.CurrentDirectory = currentDirectory;
         }
 
-        if (options == null || !Enum.IsDefined(typeof(Cli.CommandType), options.Command))
+        if (options == null || !Enum.IsDefined(options.Command))
         {
+            // Don't use the options object here, as it may not be initialized correctly
             if (result.IsSuccess())
             {
                 Colorizer.WriteLine($"[{ConsoleColor.Green}!√ Build completed.]");
@@ -105,7 +106,7 @@ public class Program
                 }
             }
 
-            Command.DisplayGitInfo(options!.Verbose);
+            Command.DisplayGitInfo();
         }
         return (int)result.Code;
     }

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -19,6 +19,8 @@ public class Program
 
     static int Main(string[] args)
     {
+        Colorizer.WriteLine($"[{ConsoleColor.Yellow}!{Nversion.Get()}]\n");
+
         var result = ResultHelper.New();
         var parserOptions = new ParserOptions
         {
@@ -39,11 +41,6 @@ public class Program
         }
         else
         {
-            if (options!.Verbose)
-            {
-                Colorizer.WriteLine($"[{ConsoleColor.Yellow}!{Nversion.Get()}]\n");
-            }
-
             parserOptions.LogParseErrorToConsole = true;
             if (!Parser.TryParse(args, out options))
             {
@@ -69,7 +66,7 @@ public class Program
                         Cli.CommandType.list => Command.List(options.Json, options.Verbose),
                         Cli.CommandType.download => Command.Download(options.Json, options.Verbose),
                         Cli.CommandType.path => Command.DisplayPathSegments(),
-                        Cli.CommandType.git_tag => Command.DisplayGitInfo(options!.Verbose),
+                        Cli.CommandType.git_info => Command.DisplayGitInfo(options!.Verbose),
                         _ => ResultHelper.Fail(-1, $"Invalid Command: '{options.Command}'"),
                     };
                 }

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -20,11 +20,11 @@ public class Program
     static int Main(string[] args)
     {
         var result = ResultHelper.New();
-        var ParserOptions = new ParserOptions
+        var parserOptions = new ParserOptions
         {
             LogParseErrorToConsole = false,
         };
-        var optionsParsed = Parser.TryParse(args, out Cli? options, ParserOptions);
+        var optionsParsed = Parser.TryParse(args, out Cli? options, parserOptions);
         if (!optionsParsed)
         {
             GitWrapper gitWrapper = new();
@@ -44,7 +44,7 @@ public class Program
                 Colorizer.WriteLine($"[{ConsoleColor.Yellow}!{Nversion.Get()}]\n");
             }
 
-            ParserOptions.LogParseErrorToConsole = true;
+            parserOptions.LogParseErrorToConsole = true;
             if (!Parser.TryParse(args, out options))
             {
                 if (!args[0].Equals("--help", StringComparison.CurrentCultureIgnoreCase))

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -195,7 +195,7 @@ public class Program
     private static ResultHelper DisplayGitInfo(bool verbose)
     {
         GitWrapper gitWrapper = new(project:null,verbose:verbose);
-        if (!gitWrapper.IsGitConfigured(silent: true) || !gitWrapper.IsGitRepository(Environment.CurrentDirectory)) return ResultHelper.Fail(-1, "folde is not git repo");
+        if (!gitWrapper.IsGitConfigured(silent: true) || !gitWrapper.IsGitRepository(Environment.CurrentDirectory)) return ResultHelper.Fail(-1, "folder is not git repo");
 
 
         // Get the directory of the current process

--- a/Nbuild/Program.cs
+++ b/Nbuild/Program.cs
@@ -66,7 +66,7 @@ public class Program
                         Cli.CommandType.list => Command.List(options.Json, options.Verbose),
                         Cli.CommandType.download => Command.Download(options.Json, options.Verbose),
                         Cli.CommandType.path => Command.DisplayPathSegments(),
-                        Cli.CommandType.git_info => Command.DisplayGitInfo(options!.Verbose),
+                        Cli.CommandType.git_info => Command.DisplayGitInfo(),
                         _ => ResultHelper.Fail(-1, $"Invalid Command: '{options.Command}'"),
                     };
                 }

--- a/dev-setup/install.ps1
+++ b/dev-setup/install.ps1
@@ -24,23 +24,22 @@ if (MainInstallApp -command install -json .\dotnet-runtime.json) {
     exit 1
 }
 
-# install Ntools
+# Call the InstallNtools function from the install module
+$result = InstallNtools
+if (-not $result) {
+    Write-OutputMessage $fileName "Failed to install NTools. Please check the logs for more details." -ForegroundColor Red
+    exit 1
+}
+
+# install apps
 #########################
-if (MainInstallApp -command install -json .\ntools.json) {
+if (MainInstallApp -command install -json .\apps.json) {
     Write-OutputMessage $fileName "Installation of ntools succeeded."
 } else {
     Write-OutputMessage $fileName "Error: Installation of ntools.json failed. Exiting script."
     exit 1
 }
 
-#install Development tools for Ntools
-#########################
-MainInstallNtools 
-#.\install-ntools.ps1 $DevDrive $MainDir
-if ($LASTEXITCODE -ne 0) {
-    Write-OutputMessage $fileName "Error: Installation of ntools failed. Exiting script."
-    exit 1
-}
 
 Write-OutputMessage $fileName "Completed installation script."
 Write-OutputMessage $fileName "EmtpyLine"

--- a/dev-setup/install.ps1
+++ b/dev-setup/install.ps1
@@ -15,12 +15,12 @@ if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     Write-OutputMessage $fileName "Admin rights detected"
 }
 
-# Install Dotnet_Runtime
+# Install dotnet-runtime
 #########################
-if (MainInstallApp -command install -json .\app-Dotnet_Runtime.json) {
-    Write-OutputMessage $fileName "Installation of app-Dotnet_Runtime succeeded."
+if (MainInstallApp -command install -json .\dotnet-runtime.json) {
+    Write-OutputMessage $fileName "Installation of dotnet-runtime succeeded."
 } else {
-    Write-OutputMessage $fileName "Error: Installation of app-Dotnet_Runtime.json failed. Exiting script."
+    Write-OutputMessage $fileName "Error: Installation of dotnet-runtime.json failed. Exiting script."
     exit 1
 }
 

--- a/dev-setup/install.psm1
+++ b/dev-setup/install.psm1
@@ -20,7 +20,6 @@
     | MainInstallApp              | Main function to install an application.                      |
     | CheckIfDotnetInstalled      | Checks if .NET Core is installed and its version.             |
     | InstallDotNetCore           | Installs .NET Core if not already installed.                  |
-    | MainInstallNtools           | Main function to install NTools (Deprecated).
     | InstallNtools               | Installs NTools by downloading and unzipping the specified version. |
     | DownloadNtools              | Downloads the specified version of NTools from GitHub.        |
     | SetDevEnvironmentVariables  | Sets development environment variables.                       |
@@ -285,21 +284,6 @@ function InstallDotNetCore {
             Write-OutputMessage $MyInvocation.MyCommand.Name "$deploymentPath already exists in the PATH environment variable."
         }
     }
-
-
-function MainInstallNtools {
-    # prepare the downloads directory
-    Write-OutputMessage "This `MainInstallNtools` function is deprecated, please use `InstallNTools` instead."
-    PrepareDownloadsDirectory $downloadsDirectory
-
-    # add deployment path to the PATH environment variable if it doesn't already exist
-    AddDeploymentPathToEnvironment $deploymentPath
-
-    & $global:NbExePath install -json $nbToolsPath
-
-    Write-OutputMessage $MyInvocation.MyCommand.Name "Completed successfully."
-    Write-OutputMessage "This `MainInstallNtools` function is deprecated, please use `InstallNTools` instead."
-}
 
 function InstallNtools {
     param (

--- a/dev-setup/ntools.json
+++ b/dev-setup/ntools.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Ntools",
-      "Version": "1.13.0",
+      "Version": "1.14.0",
       "AppFileName": "$(InstallPath)\\nb.exe",
       "WebDownloadFile": "https://github.com/naz-hage/ntools/releases/download/$(Version)/$(Version).zip",
       "DownloadedFile": "$(Version).zip",

--- a/docs/ntools/nbuild.md
+++ b/docs/ntools/nbuild.md
@@ -23,6 +23,7 @@ Below is a full list of options that can be used with `Nb.exe`:
          download        -> Downloads apps specified in the -json option (require admin privileges to run).
          targets         -> Lists available targets and saves them in the targets.md file.
          path            -> Displays environment path in local machine.
+         git_info        -> Displays the current git information in the local repository.
          ----
  (one of list,install,uninstall,download,targets,path, required)
   - json    : Specifies the JSON file that holds the list of apps. Only valid for the install, download, and list commands.


### PR DESCRIPTION
- Introduced `git_info` command in `Cli` class for displaying the current git tag.
- Added static import for `NbuildTasks.Enums` in `Command` class for better organization.
- Enhanced message display logic in `Program` class to include a verbose option.
- Updated command handling to support the new `git_tag` command.
- Refactored `DisplayGitInfo` method to return a `ResultHelper` for improved error handling.
- Updated `ntools.json` to change `Ntools` version from `1.13.0` to `1.14.0`.