### PR TITLE
Add pre_release command to GitHubRelease that gets triggered after STAGE target

### DIFF
--- a/GitHubRelease/Cli.cs
+++ b/GitHubRelease/Cli.cs
@@ -14,6 +14,7 @@ namespace GitHubRelease
         public enum CommandType
         {
             create,
+            pre_release,
             download,
         }
 
@@ -23,6 +24,7 @@ namespace GitHubRelease
         /// </summary>
         [RequiredArgument(0, "command", "Specifies the command to execute.\n" +
             "\t create \t -> Create a release. Requires repo, tag, branch and file.\n" +
+            "\t pre_release \t -> Create a pre-release. Requires repo, tag, branch and file.\n" +
             "\t download \t -> Download an asset. Requires repo, tag, and path (optional)\n" +
             "\t ----\n")]
         public CommandType Command { get; set; }
@@ -45,13 +47,13 @@ namespace GitHubRelease
         /// <summary>
         /// Gets or sets the branch name.
         /// </summary>
-        [OptionalArgument("main", "branch", "Specifies the branch name. Applicable for create command")]
+        [OptionalArgument("main", "branch", "Specifies the branch name. Applicable for create, pre_release commands")]
         public string? Branch { get; set; }
 
         /// <summary>
         /// Gets or sets the asset file name for `create` command.
         /// </summary>
-        [OptionalArgument("", "file", "Specifies the asset file name. Must include full path. Applicable for create command")]
+        [OptionalArgument("", "file", "Specifies the asset file name. Must include full path. Applicable for create, pre_release commands")]
         public string? AssetFileName { get; set; }
 
         /// <summary>
@@ -69,6 +71,7 @@ namespace GitHubRelease
         private static readonly Dictionary<string, CommandType> CommandMap = new()
                 {
                     { "create", CommandType.create },
+                    { "pre_release", CommandType.pre_release },
                     { "download", CommandType.download },
                 };
 
@@ -113,6 +116,12 @@ namespace GitHubRelease
             if (Command == CommandType.create && string.IsNullOrEmpty(AssetFileName))
             {
                 throw new ArgumentException("The 'file' option is required for the 'create' command.");
+
+            }
+
+            if (Command == CommandType.pre_release && string.IsNullOrEmpty(AssetFileName))
+            {
+                throw new ArgumentException("The 'file' option is required for the 'pre_release' command.");
 
             }
 

--- a/GitHubRelease/Command.cs
+++ b/GitHubRelease/Command.cs
@@ -20,7 +20,7 @@ namespace GitHubRelease
         /// It utilizes the ReleaseService to interact with the GitHub API.
         /// If the release creation is successful, it returns true; otherwise, it logs the error and returns false.
         /// </remarks>
-        public static async Task<bool> CreateRelease(string repo, string tag, string branch, string assetFileName)
+        public static async Task<bool> CreateRelease(string repo, string tag, string branch, string assetFileName, bool preRelease = false)
         {
             var releaseService = new ReleaseService(repo);
 
@@ -31,7 +31,7 @@ namespace GitHubRelease
                 Name = tag,
                 Body = "Description of the release",  // should be pulled from GetLatestReleaseAsync
                 Draft = false,
-                Prerelease = false
+                Prerelease = preRelease,
             };
 
             // Create a release

--- a/GitHubRelease/Program.cs
+++ b/GitHubRelease/Program.cs
@@ -1,7 +1,6 @@
 ﻿using CommandLine;
 using NbuildTasks;
 using OutputColorizer;
-using System.Xml.Linq;
 
 namespace GitHubRelease
 {
@@ -16,44 +15,51 @@ namespace GitHubRelease
                 Environment.Exit(-1);
             }
 
-            // Validate the CLI arguments
             try
             {
                 options.Validate();
-
-                //Console.WriteLine("Debug: Validated CLI arguments successfully.");
-                //Environment.Exit(0);
             }
             catch (ArgumentException ex)
             {
-                Colorizer.WriteLine($"[{ConsoleColor.Red}!Invalid arguments: {ex.Message}]");
-                Parser.DisplayHelp<Cli>();
-                Environment.Exit(1);
+                HandleError($"Invalid arguments: {ex.Message}", 1);
             }
 
             bool result = false;
             try
             {
-                result = options.Command switch
-                {
-                    Cli.CommandType.create => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!),
-                    Cli.CommandType.pre_release => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!, true),
-                    Cli.CommandType.download => await Command.DownloadAsset(options.Repo!, options.Tag!, options.AssetPath!),
-                    _ => throw new InvalidOperationException("Invalid command")
-                };
+                result = await ExecuteCommand(options);
             }
             catch (Exception ex)
             {
-                // log exception
-                Colorizer.WriteLine($"[{ConsoleColor.Red}!× " +
-                    $"'{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': Exception: {ex.Message}]");
-                Environment.Exit(-1);
+                HandleError($"Exception: {ex.Message}", -1);
             }
 
-            Colorizer.WriteLine(result
-                ? $"[{ConsoleColor.Green}!√ '{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': {options.Command} completed successfully]"
-                : $"[{ConsoleColor.Red}!× '{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': {options.Command} failed]");
+            DisplayResult(result, options.Command);
             Environment.Exit(result ? 0 : -1);
+        }
+
+        private static async Task<bool> ExecuteCommand(Cli options)
+        {
+            return options.Command switch
+            {
+                Cli.CommandType.create => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!),
+                Cli.CommandType.pre_release => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!, true),
+                Cli.CommandType.download => await Command.DownloadAsset(options.Repo!, options.Tag!, options.AssetPath!),
+                _ => throw new InvalidOperationException("Invalid command")
+            };
+        }
+
+        private static void HandleError(string message, int exitCode)
+        {
+            Colorizer.WriteLine($"[{ConsoleColor.Red}!× '{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': {message}]");
+            Environment.Exit(exitCode);
+        }
+
+        private static void DisplayResult(bool result, Cli.CommandType command)
+        {
+            Colorizer.WriteLine(result
+                ? $"[{ConsoleColor.Green}!√ '{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': {command} completed successfully]"
+                : $"[{ConsoleColor.Red}!× '{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}': {command} failed]");
         }
     }
 }

--- a/GitHubRelease/Program.cs
+++ b/GitHubRelease/Program.cs
@@ -37,6 +37,7 @@ namespace GitHubRelease
                 result = options.Command switch
                 {
                     Cli.CommandType.create => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!),
+                    Cli.CommandType.pre_release => await Command.CreateRelease(options.Repo!, options.Tag!, options.Branch!, options.AssetFileName!, true),
                     Cli.CommandType.download => await Command.DownloadAsset(options.Repo!, options.Tag!, options.AssetPath!),
                     _ => throw new InvalidOperationException("Invalid command")
                 };

--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -148,9 +148,17 @@
   </Target>
 
 	<!-- Creates a stage or prod release -->
-	<Target Name="GITHUB_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="STAGE;PROD" Condition="'$(GITHUB_ACTIONS)' != ''" >
+	<Target Name="GITHUB_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="PROD" Condition="'$(GITHUB_ACTIONS)' != ''" >
 		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
 		<Exec Command='"$(BuildTools)\GitHubRelease.exe" create -repo $(SolutionName) -tag $(ProductVersion) -branch $(GitBranch) -file $(ArtifactsFolder).zip' WorkingDirectory="$(BuildTools)" />
+
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- Creates a stage or prod pre-release -->
+	<Target Name="GITHUB_PRE_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="STAGE" Condition="'$(GITHUB_ACTIONS)' != ''" >
+		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
+		<Exec Command='"$(BuildTools)\GitHubRelease.exe" pre_release -repo $(SolutionName) -tag $(ProductVersion) -branch $(GitBranch) -file $(ArtifactsFolder).zip' WorkingDirectory="$(BuildTools)" />
 
 		<Message Text="==> DONE"/>
 	</Target>

--- a/Nbuild/resources/ntools.json
+++ b/Nbuild/resources/ntools.json
@@ -112,7 +112,7 @@
     },
     {
       "Name": "Python",
-      "Version": "3.12.2",
+      "Version": "3.13.3",
       "AppFileName": "$(InstallPath)\\python.exe",
       "WebDownloadFile": "https://www.python.org/ftp/python/$(Version)/python-$(Version)-amd64.exe",
       "DownloadedFile": "python-$(Version)-amd64.exe",

--- a/NbuildTests/BuildStarterTests.cs
+++ b/NbuildTests/BuildStarterTests.cs
@@ -24,6 +24,7 @@ namespace Nbuild.Tests
                 "STAGE",
                 "PROD",
                 "GITHUB_RELEASE",
+                "GITHUB_PRE_RELEASE",
                 "STAGE_DEPLOY",
                 "PROD_DEPLOY",
                 "SOLUTION",
@@ -35,7 +36,7 @@ namespace Nbuild.Tests
                 "TEST_DEBUG",
                 "IS_ADMIN",
                 "SingleProject",
-                "HandleError",
+                "HandleError"
             ];
 
             // Act

--- a/dev-setup/apps.json
+++ b/dev-setup/apps.json
@@ -192,7 +192,7 @@
     },
     {
       "Name": "Python",
-      "Version": "3.12.2",
+      "Version": "3.13.3",
       "AppFileName": "$(InstallPath)\\python.exe",
       "WebDownloadFile": "https://www.python.org/ftp/python/$(Version)/python-$(Version)-amd64.exe",
       "DownloadedFile": "python-$(Version)-amd64.exe",

--- a/dev-setup/python.json
+++ b/dev-setup/python.json
@@ -3,7 +3,7 @@
   "NbuildAppList": [
     {
       "Name": "Python",
-      "Version": "3.12.2",
+      "Version": "3.13.3",
       "AppFileName": "$(InstallPath)\\python.exe",
       "WebDownloadFile": "https://www.python.org/ftp/python/$(Version)/python-$(Version)-amd64.exe",
       "DownloadedFile": "python-$(Version)-amd64.exe",

--- a/docs/ntools/github-release.md
+++ b/docs/ntools/github-release.md
@@ -87,16 +87,17 @@ The access token must have the following permissions:
 GitHubRelease.exe command [-repo value] [-tag value] [-branch value] [-file value] [-path value] [-v value]
   - command : Specifies the command to execute.
          create          -> Create a release. Requires repo, tag, branch and file.
+         pre_release     -> Create a pre_release. Requires repo, tag, branch and file.
          download        -> Download an asset. Requires repo, tag, and path (optional)
          ----
- (one of create,download, required)
+ (one of create,pre_release,download, required)
   - repo    : Specifies the Git repository in the format any of the following formats:
          repoName  (UserName is declared the `OWNER` environment variable)
          userName/repoName
          https://github.com/userName/repoName (Full URL to the repository on GitHub). This is applicable to all commands. (string, default=)
   - tag     : Specifies the tag name. Applicable for all commands (string, default=)
-  - branch  : Specifies the branch name. Applicable for create command (string, default=main)
-  - file    : Specifies the asset file name. Must include full path. Applicable for create command (string, default=)
+  - branch  : Specifies the branch name. Applicable for create, pre_release commands (string, default=main)
+  - file    : Specifies the asset file name. Must include full path. Applicable for create, pre_release commands (string, default=)
   - path    : Specifies the asset path. Must be an absolute path. (string, default=)
   - v       : Optional parameter which sets the console output verbose level. (true or false, default=False)
 ```
@@ -105,6 +106,13 @@ To create a release for the repository `my-repo` with the tag `1.0.0`, branch `m
 
 ```batch
 GitHubRelease.exe create -repo userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip
+```
+
+### Example: Creating a Pre-Release
+To create a pre-release for the repository `my-repo` with the tag `1.0.0`, branch `main`, and an asset located at `C:\Releases\1.0.0.zip`, you would use the following command:
+
+```batch
+GitHubRelease.exe pre_release -repo userName/my-repo -tag 1.0.0 -branch main -file C:\Releases\1.1.0.zip
 ```
 
 ### Example: Downloading an Asset

--- a/docs/ntools/ntools.md
+++ b/docs/ntools/ntools.md
@@ -22,7 +22,7 @@ The [Windows dev environment](https://learn.microsoft.com/en-us/windows/dev-envi
 | [PowerShell](https://github.com/PowerShell/PowerShell/releases)                                          | 7.5.1       | 26-May-25       |
 | [NuGet](https://www.nuget.org/downloads)                                                                 | 6.13.2      | 10-mar-25       |
 | [SysInternals](https://learn.microsoft.com/en-us/sysinternals/)                                          | 2.90.0      | 22-Jun-24       |
-| [Python](https://www.python.org/downloads/)                                                               | 3.13.2      | 10-mar-25       |
+| [Python](https://www.python.org/downloads/)                                                               | 3.13.2      | 28-apr-25       |
 | [Argo CD](https://github.com/argoproj/argo-cd/releases/)                                          | 2.14.5      | 12-mar-25       |
 | [minikube](https://github.com/kubernetes/minikube/releases/)                                          | 1.35.0      | 12-mar-25       |
 | [kubernetes](https://github.com/kubernetes/kubernetes/releases)                                          | 1.32.2      | 12-mar-25       |

--- a/go/apps.json
+++ b/go/apps.json
@@ -192,7 +192,7 @@
     },
     {
       "Name": "Python",
-      "Version": "3.12.2",
+      "Version": "3.13.3",
       "AppFileName": "$(InstallPath)\\python.exe",
       "WebDownloadFile": "https://www.python.org/ftp/python/$(Version)/python-$(Version)-amd64.exe",
       "DownloadedFile": "python-$(Version)-amd64.exe",

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -8,7 +8,7 @@
         <!-- This is the folder where the *.sln resides-->
 		<DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
 		<!--  Modify these paths to match your Python installation -->
-		<PythonPath>$(ProgramFiles)\Python\3.12.2</PythonPath>
+		<PythonPath>$(ProgramFiles)\Python\3.13.3</PythonPath>
 		<PipPath>$(PythonPath)\Scripts\pip.exe</PipPath>
 		<MkDocsExe>$(USERPROFILE)\AppData\Roaming\Python\Python312\Scripts\mkdocs.exe</MkDocsExe>
 	</PropertyGroup>

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -216,9 +216,18 @@
 	</Target>
 
 	<!-- Creates a stage or prod release -->
-	<Target Name="GITHUB_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="STAGE;PROD" >
+	<Target Name="GITHUB_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="PROD" >
 		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
 		<Exec Command='"$(OutputPathRelease)\GitHubRelease.exe" create -repo $(SolutionName) -tag $(ProductVersion) -branch $(GitBranch) -file $(ArtifactsFolder).zip' WorkingDirectory="$(OutputPathRelease)" />
+		<Exec Command="echo GitHubRelease exit Code: %ERRORLEVEL%" />
+
+		<Message Text="==> DONE"/>
+	</Target>
+
+	<!-- Creates a stage or prod pre-release -->
+	<Target Name="GITHUB_PRE_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="STAGE" >
+		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
+		<Exec Command='"$(OutputPathRelease)\GitHubRelease.exe" pre_release -repo $(SolutionName) -tag $(ProductVersion) -branch $(GitBranch) -file $(ArtifactsFolder).zip' WorkingDirectory="$(OutputPathRelease)" />
 		<Exec Command="echo GitHubRelease exit Code: %ERRORLEVEL%" />
 
 		<Message Text="==> DONE"/>


### PR DESCRIPTION
- The GITHUB_PRE_RELEASE target is now configured to execute only after the STAGE target, and the GITHUB_RELEASE target is set to execute only after the PROD target.
- GITHUB_PRE_RELEASE uses `pre_release` instead of `create` command.
- `pre_release` works the same as `create` except it marks a GitHub release as `pre-release`.