### PR TITLE
230: Fix conflicting tag issue in PROD and STAGE builds

### DIFF
--- a/Nbuild/resources/common.targets
+++ b/Nbuild/resources/common.targets
@@ -158,7 +158,10 @@
 
 	<!-- Creates a stage or prod release -->
 	<Target Name="GITHUB_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="PROD" Condition="'$(GITHUB_ACTIONS)' != ''" >
-		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
+		<Git Command="PushTag" TaskParameter="$(ProductVersion)">
+			<Output TaskParameter="Output" PropertyName="PushResult"/>
+		</Git>
+		<RedError Condition="'$(PushResult)' != 'True'" Message="Failed to push tag $(ProductVersion) to remote repository. Build cannot continue with version conflicts." />
 		<Exec Command='"$(BuildTools)\nb.exe"  release_create --repo $(OWNER)/$(SolutionName) --tag $(ProductVersion) --branch $(GitBranch) --file $(ArtifactsFolder).zip' WorkingDirectory="$(BuildTools)" />
 
 		<Message Text="==> DONE"/>
@@ -166,7 +169,10 @@
 
 	<!-- Creates a stage or prod pre-release -->
 	<Target Name="GITHUB_PRE_RELEASE" DependsOnTargets="ARTIFACTS;GIT_BRANCH" AfterTargets="STAGE" Condition="'$(GITHUB_ACTIONS)' != ''" >
-		<Git Command="PushTag" TaskParameter="$(ProductVersion)" />
+		<Git Command="PushTag" TaskParameter="$(ProductVersion)">
+			<Output TaskParameter="Output" PropertyName="PushResult"/>
+		</Git>
+		<RedError Condition="'$(PushResult)' != 'True'" Message="Failed to push tag $(ProductVersion) to remote repository. Build cannot continue with version conflicts." />
 		<Exec Command='"$(BuildTools)\nb.exe" pre_release_create --repo $(OWNER)/$(SolutionName) --tag $(ProductVersion) --branch $(GitBranch) --file $(ArtifactsFolder).zip' WorkingDirectory="$(BuildTools)" />
 
 		<Message Text="==> DONE"/>

--- a/NbuildTasks/Git.cs
+++ b/NbuildTasks/Git.cs
@@ -12,6 +12,7 @@ namespace NbuildTasks
         private const string SetTagCommand = "SetTag";
         private const string DeleteTagCommand = "DeleteTag";
         private const string PushTagCommand = "PushTag";
+        private const string RemoteTagExistsCommand = "RemoteTagExists";
 
         [Required]
         public string Command { get; set; }
@@ -91,6 +92,18 @@ namespace NbuildTasks
                     {
                         Log.LogMessage($"Tag: {TaskParameter}");
                         Output = gitWrapper.PushTag(TaskParameter) ? "True" : "False";
+                    }
+                    else
+                    {
+                        Log.LogError($"Tag is null or empty");
+                    }
+                    break;
+
+                case RemoteTagExistsCommand:
+                    if (!string.IsNullOrEmpty(TaskParameter))
+                    {
+                        Log.LogMessage($"Tag: {TaskParameter}");
+                        Output = gitWrapper.RemoteTagExists(TaskParameter) ? "True" : "False";
                     }
                     else
                     {


### PR DESCRIPTION
## Description
PROD and STAGE builds were failing to increment versions properly due to conflicting git tags. When AUTOTAG_PROD or AUTOTAG_STAGE generated a version tag that already existed on remote (but on a different commit), the tag push would fail silently, leaving the version stuck.

This PR implements a comprehensive fix with both reactive error handling and proactive conflict prevention.

## Changes Made
**common.targets (GITHUB_RELEASE & GITHUB_PRE_RELEASE targets):**
- Capture PushTag result in `PushResult` property
- Fail build with `RedError` if tag push fails
- Provide clear error message indicating version conflict

**Git.cs:**
- Add `RemoteTagExistsCommand` to check if a tag exists on remote repository
- Returns "True"/"False" for MSBuild integration

**GitWrapper.cs (ProdTag & StageTag methods):**
- Increment version numbers in a loop until finding a tag that doesn't exist on remote
- Check remote tag existence before settling on a version
- Update documentation to reflect new behavior
- ProdTag: Increments minor version until unique
- StageTag: Increments patch version until unique

## Why These Changes
**Problem:** Version increments were stuck at 6.45.0 because builds succeeded despite tag push failures, leading to repeated attempts with the same conflicting tag.

**Solution:** 
1. **Reactive:** Build fails immediately when tag push fails
2. **Proactive:** Version generation avoids conflicts before pushing

**Benefits:**
- No more silent failures in CI/CD pipelines
- No manual intervention needed for version conflicts
- Clear error messages for troubleshooting
- Prevents future version stagnation

## Testing
- [ ] Modified GITHUB_RELEASE and GITHUB_PRE_RELEASE targets validate PushTag results
- [ ] ProdTag() increments through conflicting versions to find unique tag
- [ ] StageTag() increments through conflicting versions to find unique tag
- [ ] Build fails with clear error message when tag push fails
- [ ] RemoteTagExistsCommand correctly identifies remote tags

**Manual Validation:**
- Tested tag conflict scenarios locally
- Verified build fails on tag push failure
- Confirmed version increment logic works correctly

## Breaking Changes
None. This is a bug fix that preserves existing behavior while adding error detection.

## Notes
- This fix addresses issue #230
- Changes are backward compatible with existing build processes
- The RemoteTagExistsCommand infrastructure is available for future use but not currently called from MSBuild targets

Related Work Item: #230