### PR TITLE
243: Implement API-driven pipeline command infrastructure for both GitHub Actions and Azure DevOps platforms.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,4 @@ BuildToolsTest/
 # Documentation files that should not be tracked
 docs/todo.md
 /build-errors.txt
+/test-pipeline.txt

--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,4 @@ BuildToolsTest/
 docs/todo.md
 /build-errors.txt
 /test-pipeline.txt
+/test-workflow.yml

--- a/Nbuild/Nbuild.csproj
+++ b/Nbuild/Nbuild.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	<PackageReference Include="System.CommandLine" Version="2.0.1" />
+	<PackageReference Include="System.CommandLine" Version="2.0.2" />
 	</ItemGroup>
  <ItemGroup>
     <ProjectReference Include="..\GitHubRelease\GitHubRelease.csproj" />

--- a/Sdo/Commands/PipelineCommand.cs
+++ b/Sdo/Commands/PipelineCommand.cs
@@ -1688,6 +1688,26 @@ namespace Sdo.Commands
                 Console.WriteLine($"  Logs URL:    {build.Logs?.Url ?? "not available"}");
                 Console.WriteLine($"  Build URL:   {build.Url ?? "not available"}");
 
+                // Attempt to download and display log content
+                try
+                {
+                    var logText = await client.GetBuildLogsAsync(project, build.Id);
+                    if (!string.IsNullOrWhiteSpace(logText))
+                    {
+                        Console.WriteLine();
+                        ConsoleHelper.WriteLine("--- Log Content ---", ConsoleColor.Yellow);
+                        Console.WriteLine(logText.TrimEnd());
+                    }
+                    else
+                    {
+                        Console.WriteLine("[No log content available or failed to download]");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ConsoleHelper.WriteError($"X Error downloading build logs: {ex.Message}");
+                }
+
                 return 0;
             }
             catch (Exception ex)

--- a/Sdo/Commands/PipelineCommand.cs
+++ b/Sdo/Commands/PipelineCommand.cs
@@ -126,8 +126,8 @@ namespace Sdo.Commands
         private void AddLogsCommand(Option<bool> verboseOption)
         {
             var logsCommand = new System.CommandLine.Command("logs", "Retrieve pipeline execution logs");
-            var buildIdArg = new Argument<int?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
-            var buildIdOption = new Option<int?>("--build-id") { Description = "Build/run ID" };
+            var buildIdArg = new Argument<long?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
+            var buildIdOption = new Option<long?>("--build-id") { Description = "Build/run ID" };
 
             logsCommand.Add(buildIdArg);
             logsCommand.Add(buildIdOption);
@@ -167,12 +167,20 @@ namespace Sdo.Commands
         private void AddShowCommand(Option<bool> verboseOption)
         {
             var showCommand = new System.CommandLine.Command("show", "Display pipeline/workflow details");
+            var pipelineIdOrNameArg = new Argument<string?>("pipeline-id-or-name")
+            {
+                Arity = ArgumentArity.ZeroOrOne,
+                Description = "Pipeline ID or name (optional; Azure DevOps only)"
+            };
+
+            showCommand.Add(pipelineIdOrNameArg);
             showCommand.Add(verboseOption);
 
             showCommand.SetAction(async (parseResult) =>
             {
+                var pipelineIdOrName = parseResult.GetValue(pipelineIdOrNameArg);
                 var verbose = parseResult.GetValue(verboseOption);
-                return await ShowPipeline(verbose);
+                return await ShowPipeline(pipelineIdOrName, verbose);
             });
 
             Subcommands.Add(showCommand);
@@ -181,7 +189,7 @@ namespace Sdo.Commands
         private void AddStatusCommand(Option<bool> verboseOption)
         {
             var statusCommand = new System.CommandLine.Command("status", "Query pipeline build/run status");
-            var buildIdArg = new Argument<int?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
+            var buildIdArg = new Argument<long?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
 
             statusCommand.Add(buildIdArg);
             statusCommand.Add(verboseOption);
@@ -569,19 +577,218 @@ namespace Sdo.Commands
             }
         }
 
-        private async Task<int> GetLogs(int? buildId, bool verbose)
+        private async Task<int> GetLogs(long? buildId, bool verbose)
         {
-            Console.WriteLine("X Pipeline logs command not yet implemented");
-            return 1;
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Retrieving pipeline logs from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("run logs");
+                    }
+                    return await GetGitHubLogs(repoInfo.Owner, repoInfo.Repo, buildId, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("build logs");
+                    }
+                    return await GetAzureDevOpsLogs(repoInfo.Organization, repoInfo.Project, repoInfo.Repository, buildId, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error retrieving logs: {ex.Message}");
+                return 1;
+            }
         }
 
         private async Task<int> RunPipeline(string? pipelineName, string branch, bool verbose)
         {
-            Console.WriteLine("X Pipeline run command not yet implemented");
-            return 1;
+            try
+            {
+                if (string.IsNullOrWhiteSpace(branch))
+                {
+                    ConsoleHelper.WriteError("X Branch is required to run a pipeline. Use --branch <name>");
+                    return 1;
+                }
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose) DisplayGitHubMapping("workflow run");
+
+                    using var client = new Sdo.Services.GitHubClient();
+
+                    // Resolve workflow id
+                    long? workflowId = null;
+                    if (!string.IsNullOrWhiteSpace(pipelineName) && long.TryParse(pipelineName, out var parsedId))
+                    {
+                        workflowId = parsedId;
+                    }
+                    else
+                    {
+                        var workflows = await client.ListWorkflowsAsync(repoInfo.Owner, repoInfo.Repo);
+                        if (workflows == null || workflows.Count == 0)
+                        {
+                            ConsoleHelper.WriteError("X No workflows found in repository");
+                            return 1;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(pipelineName))
+                        {
+                            var match = workflows.FirstOrDefault(w => string.Equals(w.Name, pipelineName, StringComparison.OrdinalIgnoreCase) || (w.Path ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase));
+                            if (match != null) workflowId = match.Id;
+                        }
+
+                        // fallback: pick first active workflow
+                        if (!workflowId.HasValue)
+                        {
+                            var first = workflows.FirstOrDefault(w => string.Equals(w.State, "active", StringComparison.OrdinalIgnoreCase)) ?? workflows.First();
+                            workflowId = first.Id;
+                        }
+                    }
+
+                    if (!workflowId.HasValue)
+                    {
+                        ConsoleHelper.WriteError("X Could not resolve workflow to run");
+                        return 1;
+                    }
+
+                    var branchRef = branch.StartsWith("refs/") ? branch : branch;
+                    var triggered = await client.TriggerWorkflowAsync(repoInfo.Owner, repoInfo.Repo, workflowId.Value, branchRef);
+                    if (!triggered)
+                    {
+                        ConsoleHelper.WriteError("X Failed to trigger GitHub workflow");
+                        return 1;
+                    }
+
+                    ConsoleHelper.WriteLine($"[OK] Workflow dispatch triggered (workflow id: {workflowId.Value})", ConsoleColor.Green);
+
+                    // Try to find the created run
+                    var runs = await client.ListWorkflowRunsAsync(repoInfo.Owner, repoInfo.Repo, workflowId, 5);
+                    var run = runs?.FirstOrDefault(r => string.Equals(r.HeadBranch, branch, StringComparison.OrdinalIgnoreCase)) ?? runs?.OrderByDescending(r => r.CreatedAt).FirstOrDefault();
+                    if (run != null)
+                    {
+                        Console.WriteLine($"Run ID: {run.Id}  Status: {run.Status ?? "unknown"}  URL: {run.HtmlUrl}");
+                    }
+
+                    return 0;
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (string.IsNullOrEmpty(repoInfo.Organization) || string.IsNullOrEmpty(repoInfo.Project))
+                    {
+                        ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                        return 1;
+                    }
+
+                    var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                    if (string.IsNullOrEmpty(pat))
+                    {
+                        ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                        Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                        return 1;
+                    }
+
+                    using var client = new Sdo.Services.AzureDevOpsClient(pat, repoInfo.Organization, repoInfo.Project);
+
+                    int? definitionId = null;
+                    if (!string.IsNullOrWhiteSpace(pipelineName) && int.TryParse(pipelineName, out var parsed))
+                    {
+                        definitionId = parsed;
+                    }
+                    else
+                    {
+                        var pipelines = await client.ListPipelinesAsync(repoInfo.Project);
+                        if (pipelines == null || pipelines.Count == 0)
+                        {
+                            ConsoleHelper.WriteError("X No pipelines found in project");
+                            return 1;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(pipelineName))
+                        {
+                            var match = pipelines.FirstOrDefault(p => string.Equals(p.Name, pipelineName, StringComparison.OrdinalIgnoreCase) || (p.Path ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase));
+                            if (match != null) definitionId = match.Id;
+                        }
+
+                        if (!definitionId.HasValue)
+                        {
+                            // Try to find pipeline matching repository name
+                            var repoMatch = pipelines.FirstOrDefault(p => (p.Name ?? "").Contains(repoInfo.Repository ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+                            if (repoMatch != null) definitionId = repoMatch.Id;
+                        }
+
+                        if (!definitionId.HasValue)
+                        {
+                            // Fallback to first pipeline
+                            definitionId = pipelines.First().Id;
+                        }
+                    }
+
+                    if (!definitionId.HasValue)
+                    {
+                        ConsoleHelper.WriteError("X Could not resolve pipeline definition id to run");
+                        return 1;
+                    }
+
+                    var buildId = await client.RunPipelineAsync(repoInfo.Project, definitionId.Value, branch);
+                    if (buildId < 0)
+                    {
+                        ConsoleHelper.WriteError($"X Failed to queue build: {client.LastError}");
+                        return 1;
+                    }
+
+                    ConsoleHelper.WriteLine($"[OK] Build queued (ID: {buildId})", ConsoleColor.Green);
+                    var build = await client.GetBuildAsync(repoInfo.Project, buildId);
+                    if (build != null)
+                    {
+                        Console.WriteLine($"  Pipeline: {build.Definition?.Name}  Build Number: {build.BuildNumber}  Status: {build.Status}");
+                    }
+
+                    return 0;
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error running pipeline: {ex.Message}");
+                return 1;
+            }
         }
 
-        private async Task<int> ShowPipeline(bool verbose)
+        private async Task<int> ShowPipeline(string? pipelineIdOrName, bool verbose)
         {
             try
             {
@@ -614,7 +821,7 @@ namespace Sdo.Commands
                     {
                         DisplayAzureDevOpsMapping("pipeline show");
                     }
-                    return await ShowAzureDevOpsPipeline(repoInfo.Organization, repoInfo.Project, repoInfo.Repository, verbose);
+                    return await ShowAzureDevOpsPipeline(repoInfo.Organization, repoInfo.Project, repoInfo.Repository, pipelineIdOrName, verbose);
                 }
 
                 ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
@@ -675,7 +882,7 @@ namespace Sdo.Commands
             }
         }
 
-        private async Task<int> ShowAzureDevOpsPipeline(string? organization, string? project, string? repository, bool verbose)
+        private async Task<int> ShowAzureDevOpsPipeline(string? organization, string? project, string? repository, string? pipelineIdOrName, bool verbose)
         {
             try
             {
@@ -704,6 +911,38 @@ namespace Sdo.Commands
 
                 using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
                 {
+                    if (!string.IsNullOrWhiteSpace(pipelineIdOrName))
+                    {
+                        var pipeline = await client.GetPipelineAsync(project, pipelineIdOrName);
+                        if (pipeline == null)
+                        {
+                            var details = string.IsNullOrEmpty(client.LastError) ? string.Empty : $": {client.LastError}";
+                            ConsoleHelper.WriteError($"X Pipeline not found{details}");
+                            return 1;
+                        }
+
+                        Console.WriteLine();
+                        ConsoleHelper.WriteLine("✓ Pipeline details:", ConsoleColor.Cyan);
+                        Console.WriteLine($"  Name: {pipeline.Name ?? "Unnamed Pipeline"}");
+                        Console.WriteLine($"  ID: {pipeline.Id}");
+                        Console.WriteLine($"  Status: {pipeline.QueueStatus ?? "unknown"}");
+                        Console.WriteLine($"  Type: {pipeline.Type ?? "unknown"}");
+                        if (!string.IsNullOrEmpty(pipeline.Path))
+                        {
+                            Console.WriteLine($"  Path: {pipeline.Path}");
+                        }
+                        if (pipeline.CreatedDate.HasValue)
+                        {
+                            Console.WriteLine($"  Created: {pipeline.CreatedDate:g}");
+                        }
+                        if (pipeline.ModifiedDate.HasValue)
+                        {
+                            Console.WriteLine($"  Modified: {pipeline.ModifiedDate:g}");
+                        }
+
+                        return 0;
+                    }
+
                     var pipelines = await client.ListPipelinesAsync(project);
 
                     if (pipelines == null || pipelines.Count == 0)
@@ -837,13 +1076,14 @@ namespace Sdo.Commands
 
                 using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
                 {
-                    // For now, show what would happen
-                    // In a real implementation, we would call DeletePipelineAsync
-                    ConsoleHelper.WriteLine($"[OK] Pipeline deletion would be processed", ConsoleColor.Green);
-                    Console.WriteLine();
-                    ConsoleHelper.WriteLine($"Details:", ConsoleColor.Cyan);
-                    Console.WriteLine($"  Pipeline ID: {pipelineId}");
-                    Console.WriteLine($"  Project: {project}");
+                    var success = await client.DeletePipelineAsync(project, pipelineId);
+                    if (!success)
+                    {
+                        ConsoleHelper.WriteError($"X Failed to delete pipeline: {client.LastError}");
+                        return 1;
+                    }
+
+                    ConsoleHelper.WriteLine($"[OK] Pipeline '{pipelineId}' deleted successfully.", ConsoleColor.Green);
                 }
 
                 return 0;
@@ -867,34 +1107,33 @@ namespace Sdo.Commands
                     Console.WriteLine($"Workflows location: .github/workflows/");
                 }
 
-                // Fetch workflows from GitHub API first
+                // Fetch recent workflow runs directly
                 using (var client = new Sdo.Services.GitHubClient())
                 {
-                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 10);
 
-                    if (workflows == null || workflows.Count == 0)
+                    if (runs == null || runs.Count == 0)
                     {
-                        ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
+                        ConsoleHelper.WriteLine("No workflow runs found in this repository.", ConsoleColor.Yellow);
                         return 0;
                     }
 
-                    // For now, show the workflows available
                     Console.WriteLine();
                     ConsoleHelper.WriteLine("✓ Latest workflow runs:", ConsoleColor.Cyan);
                     Console.WriteLine();
-                    Console.WriteLine($"{"Workflow Name",-40} {"Last Run",-20} {"Status"}");
-                    Console.WriteLine(new string('-', 70));
+                    Console.WriteLine($"{"Run ID",-12} {"Workflow Name",-35} {"Last Run",-20} {"Status",-12} {"Result"}");
+                    Console.WriteLine(new string('-', 90));
 
-                    foreach (var workflow in workflows.Take(5))
+                    foreach (var run in runs)
                     {
-                        var name = workflow.Name ?? "Unnamed Workflow";
-                        if (name.Length > 38)
-                        {
-                            name = name.Substring(0, 35) + "...";
-                        }
+                        var name = run.Name ?? "Unnamed";
+                        if (name.Length > 33)
+                            name = name.Substring(0, 30) + "...";
 
-                        var lastRun = workflow.UpdatedAt.HasValue ? workflow.UpdatedAt.Value.ToString("g") : "Never";
-                        Console.WriteLine($"{name,-40} {lastRun,-20} {workflow.State}");
+                        var lastRun = run.UpdatedAt.HasValue ? run.UpdatedAt.Value.ToString("g") : "Unknown";
+                        var status = run.Status ?? "unknown";
+                        var result = run.Conclusion ?? "pending";
+                        Console.WriteLine($"{run.Id,-12} {name,-35} {lastRun,-20} {status,-12} {result}");
                     }
                 }
 
@@ -1149,7 +1388,7 @@ namespace Sdo.Commands
             return Task.FromResult<string?>(null);
         }
 
-        private async Task<int> GetStatus(int? buildId, bool verbose)
+        private async Task<int> GetStatus(long? buildId, bool verbose)
         {
             try
             {
@@ -1195,29 +1434,56 @@ namespace Sdo.Commands
             }
         }
 
-        private async Task<int> GetGitHubRunStatus(string owner, string repo, int? buildId, bool verbose)
+        private async Task<int> GetGitHubRunStatus(string owner, string repo, long? buildId, bool verbose)
         {
             try
             {
                 ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
 
+                using var client = new Sdo.Services.GitHubClient();
+                GitHubWorkflowRun? run;
+
                 if (buildId.HasValue)
                 {
-                    if (verbose)
+                    run = await client.GetWorkflowRunAsync(owner, repo, buildId.Value);
+                    if (run == null)
                     {
-                        Console.WriteLine($"Build ID: {buildId}");
+                        ConsoleHelper.WriteError($"X Workflow run not found for ID {buildId.Value}");
+                        return 1;
                     }
                 }
                 else
                 {
-                    if (verbose)
+                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 1);
+                    run = runs?.FirstOrDefault();
+                    if (run == null)
                     {
-                        Console.WriteLine("Showing latest build/run status");
+                        ConsoleHelper.WriteLine("No workflow runs found in this repository.", ConsoleColor.Yellow);
+                        return 0;
                     }
                 }
 
-                // Placeholder: In Phase 3.5, we'll add GetRunStatusAsync to GitHubClient
-                ConsoleHelper.WriteLine("[*] Pipeline status would be displayed here", ConsoleColor.Yellow);
+                Console.WriteLine();
+                ConsoleHelper.WriteLine("✓ Workflow Run Status", ConsoleColor.Cyan);
+                Console.WriteLine($"  Run ID:     {run.Id}");
+                Console.WriteLine($"  Name:       {run.Name ?? "unknown"}");
+                Console.WriteLine($"  Run Number: {run.RunNumber}");
+                Console.WriteLine($"  Branch:     {run.HeadBranch ?? "unknown"}");
+                Console.WriteLine($"  Event:      {run.Event ?? "unknown"}");
+                Console.WriteLine($"  Status:     {run.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:     {run.Conclusion ?? "pending"}");
+                if (run.RunStartedAt.HasValue)
+                {
+                    Console.WriteLine($"  Started:    {run.RunStartedAt.Value:g}");
+                }
+                if (run.UpdatedAt.HasValue)
+                {
+                    Console.WriteLine($"  Updated:    {run.UpdatedAt.Value:g}");
+                }
+                if (!string.IsNullOrEmpty(run.HtmlUrl))
+                {
+                    Console.WriteLine($"  URL:        {run.HtmlUrl}");
+                }
 
                 return 0;
             }
@@ -1228,30 +1494,70 @@ namespace Sdo.Commands
             }
         }
 
-        private async Task<int> GetAzureDevOpsRunStatus(string? organization, string? project, string? repository, int? buildId, bool verbose)
+        private async Task<int> GetAzureDevOpsRunStatus(string? organization, string? project, string? repository, long? buildId, bool verbose)
         {
             try
             {
                 ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
                 ConsoleHelper.WriteLine($"✓ Repository: {repository ?? "unknown"}", ConsoleColor.Green);
 
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project);
+                AzureDevOpsBuild? build;
+
                 if (buildId.HasValue)
                 {
-                    if (verbose)
+                    build = await client.GetBuildAsync(project, (int)buildId.Value);
+                    if (build == null)
                     {
-                        Console.WriteLine($"Build ID: {buildId}");
+                        ConsoleHelper.WriteError($"X Build not found for ID {buildId.Value}");
+                        return 1;
                     }
                 }
                 else
                 {
-                    if (verbose)
+                    var builds = await client.ListBuildsAsync(project, 1);
+                    build = builds?.FirstOrDefault();
+                    if (build == null)
                     {
-                        Console.WriteLine("Showing latest build/run status");
+                        ConsoleHelper.WriteLine("No builds found in this project.", ConsoleColor.Yellow);
+                        return 0;
                     }
                 }
 
-                // Placeholder: In Phase 3.5, we'll add GetBuildStatusAsync to AzureDevOpsClient
-                ConsoleHelper.WriteLine("[*] Pipeline status would be displayed here", ConsoleColor.Yellow);
+                Console.WriteLine();
+                ConsoleHelper.WriteLine("✓ Build Status", ConsoleColor.Cyan);
+                Console.WriteLine($"  Build ID:    {build.Id}");
+                Console.WriteLine($"  Number:      {build.BuildNumber ?? "unknown"}");
+                Console.WriteLine($"  Pipeline:    {build.Definition?.Name ?? "unknown"}");
+                Console.WriteLine($"  Status:      {build.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:      {build.Result ?? "pending"}");
+                Console.WriteLine($"  Branch:      {build.SourceBranch ?? "unknown"}");
+                if (build.QueueTime.HasValue)
+                {
+                    Console.WriteLine($"  Queued:      {build.QueueTime.Value:g}");
+                }
+                if (build.StartTime.HasValue)
+                {
+                    Console.WriteLine($"  Started:     {build.StartTime.Value:g}");
+                }
+                if (build.FinishTime.HasValue)
+                {
+                    Console.WriteLine($"  Finished:    {build.FinishTime.Value:g}");
+                }
 
                 return 0;
             }
@@ -1262,10 +1568,192 @@ namespace Sdo.Commands
             }
         }
 
+        private async Task<int> GetGitHubLogs(string owner, string repo, long? buildId, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                using var client = new Sdo.Services.GitHubClient();
+                GitHubWorkflowRun? run;
+
+                if (buildId.HasValue)
+                {
+                    run = await client.GetWorkflowRunAsync(owner, repo, buildId.Value);
+                    if (run == null)
+                    {
+                        ConsoleHelper.WriteError($"X Workflow run not found for ID {buildId.Value}");
+                        return 1;
+                    }
+                }
+                else
+                {
+                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 1);
+                    run = runs?.FirstOrDefault();
+                    if (run == null)
+                    {
+                        ConsoleHelper.WriteLine("No workflow runs found in this repository.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+                }
+
+                Console.WriteLine();
+                ConsoleHelper.WriteLine("✓ Workflow Run Logs", ConsoleColor.Cyan);
+                Console.WriteLine($"  Run ID:      {run.Id}");
+                Console.WriteLine($"  Name:        {run.Name ?? "unknown"}");
+                Console.WriteLine($"  Status:      {run.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:      {run.Conclusion ?? "pending"}");
+                Console.WriteLine($"  Logs URL:    {run.LogsUrl ?? "not available"}");
+                Console.WriteLine($"  Details URL: {run.HtmlUrl ?? "not available"}");
+
+                // Download and print log content if available
+                if (!string.IsNullOrWhiteSpace(run.LogsUrl))
+                {
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("--- Log Content ---", ConsoleColor.Yellow);
+                    var logText = await client.DownloadAndExtractLogsAsync(run.LogsUrl);
+                    if (!string.IsNullOrWhiteSpace(logText))
+                    {
+                        Console.WriteLine(logText.TrimEnd());
+                    }
+                    else
+                    {
+                        Console.WriteLine("[No log content available or failed to download]");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("[No logs_url available for this run]");
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get GitHub logs: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetAzureDevOpsLogs(string? organization, string? project, string? repository, long? buildId, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+                ConsoleHelper.WriteLine($"✓ Repository: {repository ?? "unknown"}", ConsoleColor.Green);
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project);
+                AzureDevOpsBuild? build;
+
+                if (buildId.HasValue)
+                {
+                    build = await client.GetBuildAsync(project, (int)buildId.Value);
+                    if (build == null)
+                    {
+                        ConsoleHelper.WriteError($"X Build not found for ID {buildId.Value}");
+                        return 1;
+                    }
+                }
+                else
+                {
+                    var builds = await client.ListBuildsAsync(project, 1);
+                    build = builds?.FirstOrDefault();
+                    if (build == null)
+                    {
+                        ConsoleHelper.WriteLine("No builds found in this project.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+                }
+
+                Console.WriteLine();
+                ConsoleHelper.WriteLine("✓ Build Logs", ConsoleColor.Cyan);
+                Console.WriteLine($"  Build ID:    {build.Id}");
+                Console.WriteLine($"  Number:      {build.BuildNumber ?? "unknown"}");
+                Console.WriteLine($"  Status:      {build.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:      {build.Result ?? "pending"}");
+                Console.WriteLine($"  Logs URL:    {build.Logs?.Url ?? "not available"}");
+                Console.WriteLine($"  Build URL:   {build.Url ?? "not available"}");
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get Azure DevOps logs: {ex.Message}");
+                return 1;
+            }
+        }
+
         private async Task<int> UpdatePipeline(bool verbose)
         {
-            Console.WriteLine("X Pipeline update command not yet implemented");
-            return 1;
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Updating pipeline/workflow configuration...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose) DisplayGitHubMapping("workflow update");
+                    ConsoleHelper.WriteLine("[INFO] To update GitHub workflow, modify the .github/workflows/<file>.yml and commit/push the change.", ConsoleColor.Yellow);
+                    Console.WriteLine("  Steps:");
+                    Console.WriteLine("    1. Edit .github/workflows/<workflow-file>.yml");
+                    Console.WriteLine("    2. git add <file> && git commit -m 'Update workflow' && git push");
+                    return 0;
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (string.IsNullOrEmpty(repoInfo.Organization) || string.IsNullOrEmpty(repoInfo.Project))
+                    {
+                        ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                        return 1;
+                    }
+
+                    var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                    if (string.IsNullOrEmpty(pat))
+                    {
+                        ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                        Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                        return 1;
+                    }
+
+                    using var client = new Sdo.Services.AzureDevOpsClient(pat, repoInfo.Organization, repoInfo.Project);
+                    ConsoleHelper.WriteLine("[INFO] To update an Azure DevOps pipeline, update the YAML in your repository and commit/push. Alternatively, update the pipeline definition via Azure DevOps REST API.", ConsoleColor.Yellow);
+                    Console.WriteLine("  Steps:");
+                    Console.WriteLine("    1. Edit azure-pipelines/<pipeline>.yml");
+                    Console.WriteLine("    2. git add <file> && git commit -m 'Update pipeline' && git push");
+                    Console.WriteLine("    3. If pipeline uses pipeline definition in UI, update via Azure DevOps portal or REST API");
+                    return 0;
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error updating pipeline: {ex.Message}");
+                return 1;
+            }
         }
 
         #endregion

--- a/Sdo/Commands/PipelineCommand.cs
+++ b/Sdo/Commands/PipelineCommand.cs
@@ -438,12 +438,12 @@ namespace Sdo.Commands
                     Console.WriteLine($"Filter: {filterDisplay}");
                 }
 
-                // Fetch workflows from GitHub API
+                // Fetch neutral pipeline definitions from GitHub API
                 using (var client = new Sdo.Services.GitHubClient())
                 {
-                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+                    var definitions = await client.ListPipelineDefinitionsAsync(owner, repo);
 
-                    if (workflows == null || workflows.Count == 0)
+                    if (definitions == null || definitions.Count == 0)
                     {
                         ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
                         return 0;
@@ -452,12 +452,12 @@ namespace Sdo.Commands
                     // Apply repository name filter if specified
                     if (!string.IsNullOrEmpty(filterRepo))
                     {
-                        workflows = workflows.Where(w =>
+                        definitions = definitions.Where(w =>
                             (w.Name ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase) ||
                             (w.Path ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase)
                         ).ToList();
 
-                        if (workflows.Count == 0)
+                        if (definitions.Count == 0)
                         {
                             ConsoleHelper.WriteLine($"No workflows found matching repository filter: {filterRepo}", ConsoleColor.Yellow);
                             return 0;
@@ -470,15 +470,15 @@ namespace Sdo.Commands
                     Console.WriteLine($"{"Name",-40} {"State",-10} {"ID"}");
                     Console.WriteLine(new string('-', 60));
 
-                    foreach (var workflow in workflows)
+                    foreach (var def in definitions)
                     {
-                        var name = workflow.Name ?? "Unnamed Workflow";
+                        var name = def.Name ?? "Unnamed Workflow";
                         if (name.Length > 38)
                         {
                             name = name.Substring(0, 35) + "...";
                         }
 
-                        Console.WriteLine($"{name,-40} {workflow.State,-10} {workflow.Id}");
+                        Console.WriteLine($"{name,-40} {def.State,-10} {def.PlatformId}");
                     }
                 }
 
@@ -526,7 +526,7 @@ namespace Sdo.Commands
 
                 using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
                 {
-                    var pipelines = await client.ListPipelinesAsync(project);
+                    var pipelines = await client.ListPipelineDefinitionsAsync(project);
 
                     if (pipelines == null || pipelines.Count == 0)
                     {
@@ -563,8 +563,8 @@ namespace Sdo.Commands
                             name = name.Substring(0, 35) + "...";
                         }
 
-                        var status = pipeline.QueueStatus ?? "unknown";
-                        Console.WriteLine($"{name,-40} {status,-15} {pipeline.Id}");
+                        var status = pipeline.State ?? "unknown";
+                        Console.WriteLine($"{name,-40} {status,-15} {pipeline.PlatformId}");
                     }
                 }
 
@@ -648,7 +648,7 @@ namespace Sdo.Commands
 
                     using var client = new Sdo.Services.GitHubClient();
 
-                    // Resolve workflow id
+                    // Resolve workflow id (long) from numeric input or by name
                     long? workflowId = null;
                     if (!string.IsNullOrWhiteSpace(pipelineName) && long.TryParse(pipelineName, out var parsedId))
                     {
@@ -656,8 +656,8 @@ namespace Sdo.Commands
                     }
                     else
                     {
-                        var workflows = await client.ListWorkflowsAsync(repoInfo.Owner, repoInfo.Repo);
-                        if (workflows == null || workflows.Count == 0)
+                        var defs = await client.ListPipelineDefinitionsAsync(repoInfo.Owner, repoInfo.Repo);
+                        if (defs == null || defs.Count == 0)
                         {
                             ConsoleHelper.WriteError("X No workflows found in repository");
                             return 1;
@@ -665,15 +665,20 @@ namespace Sdo.Commands
 
                         if (!string.IsNullOrWhiteSpace(pipelineName))
                         {
-                            var match = workflows.FirstOrDefault(w => string.Equals(w.Name, pipelineName, StringComparison.OrdinalIgnoreCase) || (w.Path ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase));
-                            if (match != null) workflowId = match.Id;
+                            var match = defs.FirstOrDefault(d => string.Equals(d.Name, pipelineName, StringComparison.OrdinalIgnoreCase) || (d.Path ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase));
+                            if (match != null && long.TryParse(match.PlatformId, out var mid)) workflowId = mid;
                         }
 
                         // fallback: pick first active workflow
                         if (!workflowId.HasValue)
                         {
-                            var first = workflows.FirstOrDefault(w => string.Equals(w.State, "active", StringComparison.OrdinalIgnoreCase)) ?? workflows.First();
-                            workflowId = first.Id;
+                            var first = defs.FirstOrDefault(d => string.Equals(d.State, "active", StringComparison.OrdinalIgnoreCase)) ?? defs.First();
+                            if (!long.TryParse(first.PlatformId, out var fid))
+                            {
+                                ConsoleHelper.WriteError("X Could not parse workflow id");
+                                return 1;
+                            }
+                            workflowId = fid;
                         }
                     }
 
@@ -684,7 +689,7 @@ namespace Sdo.Commands
                     }
 
                     var branchRef = branch.StartsWith("refs/") ? branch : branch;
-                    var triggered = await client.TriggerWorkflowAsync(repoInfo.Owner, repoInfo.Repo, workflowId.Value, branchRef);
+                    var triggered = await client.TriggerPipelineAsync(repoInfo.Owner, repoInfo.Repo, workflowId.Value, branchRef);
                     if (!triggered)
                     {
                         ConsoleHelper.WriteError("X Failed to trigger GitHub workflow");
@@ -694,11 +699,11 @@ namespace Sdo.Commands
                     ConsoleHelper.WriteLine($"[OK] Workflow dispatch triggered (workflow id: {workflowId.Value})", ConsoleColor.Green);
 
                     // Try to find the created run
-                    var runs = await client.ListWorkflowRunsAsync(repoInfo.Owner, repoInfo.Repo, workflowId, 5);
-                    var run = runs?.FirstOrDefault(r => string.Equals(r.HeadBranch, branch, StringComparison.OrdinalIgnoreCase)) ?? runs?.OrderByDescending(r => r.CreatedAt).FirstOrDefault();
+                    var runs = await client.ListPipelineRunsAsync(repoInfo.Owner, repoInfo.Repo, workflowId, 5);
+                    var run = runs?.FirstOrDefault(r => string.Equals(r.Branch, branch, StringComparison.OrdinalIgnoreCase)) ?? runs?.OrderByDescending(r => r.FinishedAt ?? r.StartedAt).FirstOrDefault();
                     if (run != null)
                     {
-                        Console.WriteLine($"Run ID: {run.Id}  Status: {run.Status ?? "unknown"}  URL: {run.HtmlUrl}");
+                        Console.WriteLine($"Run ID: {run.PlatformId}  Status: {run.Status ?? "unknown"}  URL: {run.Url}");
                     }
 
                     return 0;
@@ -728,7 +733,7 @@ namespace Sdo.Commands
                     }
                     else
                     {
-                        var pipelines = await client.ListPipelinesAsync(repoInfo.Project);
+                        var pipelines = await client.ListPipelineDefinitionsAsync(repoInfo.Project);
                         if (pipelines == null || pipelines.Count == 0)
                         {
                             ConsoleHelper.WriteError("X No pipelines found in project");
@@ -738,20 +743,25 @@ namespace Sdo.Commands
                         if (!string.IsNullOrWhiteSpace(pipelineName))
                         {
                             var match = pipelines.FirstOrDefault(p => string.Equals(p.Name, pipelineName, StringComparison.OrdinalIgnoreCase) || (p.Path ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase));
-                            if (match != null) definitionId = match.Id;
+                            if (match != null && int.TryParse(match.PlatformId, out var mid)) definitionId = mid;
                         }
 
                         if (!definitionId.HasValue)
                         {
                             // Try to find pipeline matching repository name
                             var repoMatch = pipelines.FirstOrDefault(p => (p.Name ?? "").Contains(repoInfo.Repository ?? string.Empty, StringComparison.OrdinalIgnoreCase));
-                            if (repoMatch != null) definitionId = repoMatch.Id;
+                            if (repoMatch != null && int.TryParse(repoMatch.PlatformId, out var rmid)) definitionId = rmid;
                         }
 
                         if (!definitionId.HasValue)
                         {
                             // Fallback to first pipeline
-                            definitionId = pipelines.First().Id;
+                            if (!int.TryParse(pipelines.First().PlatformId, out var fid))
+                            {
+                                ConsoleHelper.WriteError("X Failed to resolve pipeline id");
+                                return 1;
+                            }
+                            definitionId = fid;
                         }
                     }
 
@@ -772,7 +782,15 @@ namespace Sdo.Commands
                     var build = await client.GetBuildAsync(repoInfo.Project, buildId);
                     if (build != null)
                     {
-                        Console.WriteLine($"  Pipeline: {build.Definition?.Name}  Build Number: {build.BuildNumber}  Status: {build.Status}");
+                        var run = build.ToPipelineRun();
+                        if (run != null)
+                        {
+                            Console.WriteLine($"  Pipeline: {run.Name}  Build Number: {run.Name}  Status: {run.Status}");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"  Pipeline: {build.Definition?.Name}  Build Number: {build.BuildNumber}  Status: {build.Status}");
+                        }
                     }
 
                     return 0;
@@ -845,12 +863,12 @@ namespace Sdo.Commands
                     Console.WriteLine($"Workflows location: .github/workflows/");
                 }
 
-                // Fetch workflows from GitHub API
+                // Fetch neutral pipeline definitions from GitHub API
                 using (var client = new Sdo.Services.GitHubClient())
                 {
-                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+                    var definitions = await client.ListPipelineDefinitionsAsync(owner, repo);
 
-                    if (workflows == null || workflows.Count == 0)
+                    if (definitions == null || definitions.Count == 0)
                     {
                         ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
                         return 0;
@@ -860,15 +878,15 @@ namespace Sdo.Commands
                     ConsoleHelper.WriteLine("✓ Workflows in this repository:", ConsoleColor.Cyan);
                     Console.WriteLine();
 
-                    foreach (var workflow in workflows)
+                    foreach (var def in definitions)
                     {
-                        var stateColor = workflow.State == "active" ? ConsoleColor.Green : ConsoleColor.Yellow;
-                        ConsoleHelper.WriteLine($"  • {workflow.Name ?? "Unnamed Workflow"}", stateColor);
-                        Console.WriteLine($"    State: {workflow.State}");
-                        Console.WriteLine($"    ID: {workflow.Id}");
-                        if (!string.IsNullOrEmpty(workflow.Path))
+                        var stateColor = (def.State ?? "").Equals("active", StringComparison.OrdinalIgnoreCase) ? ConsoleColor.Green : ConsoleColor.Yellow;
+                        ConsoleHelper.WriteLine($"  • {def.Name ?? "Unnamed Workflow"}", stateColor);
+                        Console.WriteLine($"    State: {def.State}");
+                        Console.WriteLine($"    ID: {def.PlatformId}");
+                        if (!string.IsNullOrEmpty(def.Path))
                         {
-                            Console.WriteLine($"    Path: {workflow.Path}");
+                            Console.WriteLine($"    Path: {def.Path}");
                         }
                     }
                 }
@@ -913,7 +931,7 @@ namespace Sdo.Commands
                 {
                     if (!string.IsNullOrWhiteSpace(pipelineIdOrName))
                     {
-                        var pipeline = await client.GetPipelineAsync(project, pipelineIdOrName);
+                        var pipeline = await client.GetPipelineDefinitionAsync(project, pipelineIdOrName);
                         if (pipeline == null)
                         {
                             var details = string.IsNullOrEmpty(client.LastError) ? string.Empty : $": {client.LastError}";
@@ -924,26 +942,26 @@ namespace Sdo.Commands
                         Console.WriteLine();
                         ConsoleHelper.WriteLine("✓ Pipeline details:", ConsoleColor.Cyan);
                         Console.WriteLine($"  Name: {pipeline.Name ?? "Unnamed Pipeline"}");
-                        Console.WriteLine($"  ID: {pipeline.Id}");
-                        Console.WriteLine($"  Status: {pipeline.QueueStatus ?? "unknown"}");
+                        Console.WriteLine($"  ID: {pipeline.PlatformId}");
+                        Console.WriteLine($"  Status: {pipeline.State ?? "unknown"}");
                         Console.WriteLine($"  Type: {pipeline.Type ?? "unknown"}");
                         if (!string.IsNullOrEmpty(pipeline.Path))
                         {
                             Console.WriteLine($"  Path: {pipeline.Path}");
                         }
-                        if (pipeline.CreatedDate.HasValue)
+                        if (pipeline.CreatedAt.HasValue)
                         {
-                            Console.WriteLine($"  Created: {pipeline.CreatedDate:g}");
+                            Console.WriteLine($"  Created: {pipeline.CreatedAt:g}");
                         }
-                        if (pipeline.ModifiedDate.HasValue)
+                        if (pipeline.UpdatedAt.HasValue)
                         {
-                            Console.WriteLine($"  Modified: {pipeline.ModifiedDate:g}");
+                            Console.WriteLine($"  Modified: {pipeline.UpdatedAt:g}");
                         }
 
                         return 0;
                     }
 
-                    var pipelines = await client.ListPipelinesAsync(project);
+                    var pipelines = await client.ListPipelineDefinitionsAsync(project);
 
                     if (pipelines == null || pipelines.Count == 0)
                     {
@@ -957,17 +975,17 @@ namespace Sdo.Commands
 
                     foreach (var pipeline in pipelines)
                     {
-                        var statusColor = pipeline.QueueStatus == "enabled" ? ConsoleColor.Green : ConsoleColor.Yellow;
+                        var statusColor = (pipeline.State ?? "") == "enabled" ? ConsoleColor.Green : ConsoleColor.Yellow;
                         ConsoleHelper.WriteLine($"  • {pipeline.Name ?? "Unnamed Pipeline"}", statusColor);
-                        Console.WriteLine($"    ID: {pipeline.Id}");
-                        Console.WriteLine($"    Status: {pipeline.QueueStatus}");
+                        Console.WriteLine($"    ID: {pipeline.PlatformId}");
+                        Console.WriteLine($"    Status: {pipeline.State}");
                         if (!string.IsNullOrEmpty(pipeline.Path))
                         {
                             Console.WriteLine($"    Path: {pipeline.Path}");
                         }
-                        if (pipeline.CreatedDate.HasValue)
+                        if (pipeline.CreatedAt.HasValue)
                         {
-                            Console.WriteLine($"    Created: {pipeline.CreatedDate:g}");
+                            Console.WriteLine($"    Created: {pipeline.CreatedAt:g}");
                         }
                     }
                 }
@@ -1107,10 +1125,10 @@ namespace Sdo.Commands
                     Console.WriteLine($"Workflows location: .github/workflows/");
                 }
 
-                // Fetch recent workflow runs directly
+                // Fetch recent pipeline runs (neutral) from GitHub
                 using (var client = new Sdo.Services.GitHubClient())
                 {
-                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 10);
+                    var runs = await client.ListPipelineRunsAsync(owner, repo, null, 10);
 
                     if (runs == null || runs.Count == 0)
                     {
@@ -1130,10 +1148,10 @@ namespace Sdo.Commands
                         if (name.Length > 33)
                             name = name.Substring(0, 30) + "...";
 
-                        var lastRun = run.UpdatedAt.HasValue ? run.UpdatedAt.Value.ToString("g") : "Unknown";
+                        var lastRun = run.FinishedAt.HasValue ? run.FinishedAt.Value.ToString("g") : (run.StartedAt.HasValue ? run.StartedAt.Value.ToString("g") : "Unknown");
                         var status = run.Status ?? "unknown";
-                        var result = run.Conclusion ?? "pending";
-                        Console.WriteLine($"{run.Id,-12} {name,-35} {lastRun,-20} {status,-12} {result}");
+                        var result = run.Result ?? "pending";
+                        Console.WriteLine($"{run.PlatformId,-12} {name,-35} {lastRun,-20} {status,-12} {result}");
                     }
                 }
 
@@ -1441,11 +1459,11 @@ namespace Sdo.Commands
                 ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
 
                 using var client = new Sdo.Services.GitHubClient();
-                GitHubWorkflowRun? run;
+                PipelineRun? run;
 
                 if (buildId.HasValue)
                 {
-                    run = await client.GetWorkflowRunAsync(owner, repo, buildId.Value);
+                    run = await client.GetPipelineRunAsync(owner, repo, buildId.Value);
                     if (run == null)
                     {
                         ConsoleHelper.WriteError($"X Workflow run not found for ID {buildId.Value}");
@@ -1454,7 +1472,7 @@ namespace Sdo.Commands
                 }
                 else
                 {
-                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 1);
+                    var runs = await client.ListPipelineRunsAsync(owner, repo, null, 1);
                     run = runs?.FirstOrDefault();
                     if (run == null)
                     {
@@ -1465,24 +1483,22 @@ namespace Sdo.Commands
 
                 Console.WriteLine();
                 ConsoleHelper.WriteLine("✓ Workflow Run Status", ConsoleColor.Cyan);
-                Console.WriteLine($"  Run ID:     {run.Id}");
+                Console.WriteLine($"  Run ID:     {run.PlatformId}");
                 Console.WriteLine($"  Name:       {run.Name ?? "unknown"}");
-                Console.WriteLine($"  Run Number: {run.RunNumber}");
-                Console.WriteLine($"  Branch:     {run.HeadBranch ?? "unknown"}");
-                Console.WriteLine($"  Event:      {run.Event ?? "unknown"}");
+                Console.WriteLine($"  Branch:     {run.Branch ?? "unknown"}");
                 Console.WriteLine($"  Status:     {run.Status ?? "unknown"}");
-                Console.WriteLine($"  Result:     {run.Conclusion ?? "pending"}");
-                if (run.RunStartedAt.HasValue)
+                Console.WriteLine($"  Result:     {run.Result ?? "pending"}");
+                if (run.StartedAt.HasValue)
                 {
-                    Console.WriteLine($"  Started:    {run.RunStartedAt.Value:g}");
+                    Console.WriteLine($"  Started:    {run.StartedAt.Value:g}");
                 }
-                if (run.UpdatedAt.HasValue)
+                if (run.FinishedAt.HasValue)
                 {
-                    Console.WriteLine($"  Updated:    {run.UpdatedAt.Value:g}");
+                    Console.WriteLine($"  Finished:   {run.FinishedAt.Value:g}");
                 }
-                if (!string.IsNullOrEmpty(run.HtmlUrl))
+                if (!string.IsNullOrEmpty(run.Url))
                 {
-                    Console.WriteLine($"  URL:        {run.HtmlUrl}");
+                    Console.WriteLine($"  URL:        {run.Url}");
                 }
 
                 return 0;
@@ -1516,12 +1532,12 @@ namespace Sdo.Commands
                 }
 
                 using var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project);
-                AzureDevOpsBuild? build;
+                PipelineRun? run;
 
                 if (buildId.HasValue)
                 {
-                    build = await client.GetBuildAsync(project, (int)buildId.Value);
-                    if (build == null)
+                    run = await client.GetPipelineRunAsync(project, (int)buildId.Value);
+                    if (run == null)
                     {
                         ConsoleHelper.WriteError($"X Build not found for ID {buildId.Value}");
                         return 1;
@@ -1529,9 +1545,9 @@ namespace Sdo.Commands
                 }
                 else
                 {
-                    var builds = await client.ListBuildsAsync(project, 1);
-                    build = builds?.FirstOrDefault();
-                    if (build == null)
+                    var runs = await client.ListPipelineRunsAsync(project, 1, null);
+                    run = runs?.FirstOrDefault();
+                    if (run == null)
                     {
                         ConsoleHelper.WriteLine("No builds found in this project.", ConsoleColor.Yellow);
                         return 0;
@@ -1540,23 +1556,19 @@ namespace Sdo.Commands
 
                 Console.WriteLine();
                 ConsoleHelper.WriteLine("✓ Build Status", ConsoleColor.Cyan);
-                Console.WriteLine($"  Build ID:    {build.Id}");
-                Console.WriteLine($"  Number:      {build.BuildNumber ?? "unknown"}");
-                Console.WriteLine($"  Pipeline:    {build.Definition?.Name ?? "unknown"}");
-                Console.WriteLine($"  Status:      {build.Status ?? "unknown"}");
-                Console.WriteLine($"  Result:      {build.Result ?? "pending"}");
-                Console.WriteLine($"  Branch:      {build.SourceBranch ?? "unknown"}");
-                if (build.QueueTime.HasValue)
+                Console.WriteLine($"  Build ID:    {run.PlatformId}");
+                Console.WriteLine($"  Number:      {run.Name ?? "unknown"}");
+                Console.WriteLine($"  Pipeline:    {run.Name ?? "unknown"}");
+                Console.WriteLine($"  Status:      {run.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:      {run.Result ?? "pending"}");
+                Console.WriteLine($"  Branch:      {run.Branch ?? "unknown"}");
+                if (run.StartedAt.HasValue)
                 {
-                    Console.WriteLine($"  Queued:      {build.QueueTime.Value:g}");
+                    Console.WriteLine($"  Started:     {run.StartedAt.Value:g}");
                 }
-                if (build.StartTime.HasValue)
+                if (run.FinishedAt.HasValue)
                 {
-                    Console.WriteLine($"  Started:     {build.StartTime.Value:g}");
-                }
-                if (build.FinishTime.HasValue)
-                {
-                    Console.WriteLine($"  Finished:    {build.FinishTime.Value:g}");
+                    Console.WriteLine($"  Finished:    {run.FinishedAt.Value:g}");
                 }
 
                 return 0;
@@ -1575,11 +1587,11 @@ namespace Sdo.Commands
                 ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
 
                 using var client = new Sdo.Services.GitHubClient();
-                GitHubWorkflowRun? run;
+                PipelineRun? run;
 
                 if (buildId.HasValue)
                 {
-                    run = await client.GetWorkflowRunAsync(owner, repo, buildId.Value);
+                    run = await client.GetPipelineRunAsync(owner, repo, buildId.Value);
                     if (run == null)
                     {
                         ConsoleHelper.WriteError($"X Workflow run not found for ID {buildId.Value}");
@@ -1588,7 +1600,7 @@ namespace Sdo.Commands
                 }
                 else
                 {
-                    var runs = await client.ListWorkflowRunsAsync(owner, repo, null, 1);
+                    var runs = await client.ListPipelineRunsAsync(owner, repo, null, 1);
                     run = runs?.FirstOrDefault();
                     if (run == null)
                     {
@@ -1599,19 +1611,19 @@ namespace Sdo.Commands
 
                 Console.WriteLine();
                 ConsoleHelper.WriteLine("✓ Workflow Run Logs", ConsoleColor.Cyan);
-                Console.WriteLine($"  Run ID:      {run.Id}");
+                Console.WriteLine($"  Run ID:      {run.PlatformId}");
                 Console.WriteLine($"  Name:        {run.Name ?? "unknown"}");
                 Console.WriteLine($"  Status:      {run.Status ?? "unknown"}");
-                Console.WriteLine($"  Result:      {run.Conclusion ?? "pending"}");
-                Console.WriteLine($"  Logs URL:    {run.LogsUrl ?? "not available"}");
-                Console.WriteLine($"  Details URL: {run.HtmlUrl ?? "not available"}");
+                Console.WriteLine($"  Result:      {run.Result ?? "pending"}");
+                Console.WriteLine($"  Details URL: {run.Url ?? "not available"}");
 
-                // Download and print log content if available
-                if (!string.IsNullOrWhiteSpace(run.LogsUrl))
+                // Download and print log content
+                long runId;
+                if (long.TryParse(run.PlatformId, out runId))
                 {
                     Console.WriteLine();
                     ConsoleHelper.WriteLine("--- Log Content ---", ConsoleColor.Yellow);
-                    var logText = await client.DownloadAndExtractLogsAsync(run.LogsUrl);
+                    var logText = await client.GetPipelineRunLogsAsync(owner, repo, runId);
                     if (!string.IsNullOrWhiteSpace(logText))
                     {
                         Console.WriteLine(logText.TrimEnd());
@@ -1623,7 +1635,7 @@ namespace Sdo.Commands
                 }
                 else
                 {
-                    Console.WriteLine("[No logs_url available for this run]");
+                    Console.WriteLine("[No run id available to download logs]");
                 }
 
                 return 0;
@@ -1657,12 +1669,12 @@ namespace Sdo.Commands
                 }
 
                 using var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project);
-                AzureDevOpsBuild? build;
+                PipelineRun? run;
 
                 if (buildId.HasValue)
                 {
-                    build = await client.GetBuildAsync(project, (int)buildId.Value);
-                    if (build == null)
+                    run = await client.GetPipelineRunAsync(project, (int)buildId.Value);
+                    if (run == null)
                     {
                         ConsoleHelper.WriteError($"X Build not found for ID {buildId.Value}");
                         return 1;
@@ -1670,9 +1682,9 @@ namespace Sdo.Commands
                 }
                 else
                 {
-                    var builds = await client.ListBuildsAsync(project, 1);
-                    build = builds?.FirstOrDefault();
-                    if (build == null)
+                    var runs = await client.ListPipelineRunsAsync(project, 1, null);
+                    run = runs?.FirstOrDefault();
+                    if (run == null)
                     {
                         ConsoleHelper.WriteLine("No builds found in this project.", ConsoleColor.Yellow);
                         return 0;
@@ -1681,26 +1693,32 @@ namespace Sdo.Commands
 
                 Console.WriteLine();
                 ConsoleHelper.WriteLine("✓ Build Logs", ConsoleColor.Cyan);
-                Console.WriteLine($"  Build ID:    {build.Id}");
-                Console.WriteLine($"  Number:      {build.BuildNumber ?? "unknown"}");
-                Console.WriteLine($"  Status:      {build.Status ?? "unknown"}");
-                Console.WriteLine($"  Result:      {build.Result ?? "pending"}");
-                Console.WriteLine($"  Logs URL:    {build.Logs?.Url ?? "not available"}");
-                Console.WriteLine($"  Build URL:   {build.Url ?? "not available"}");
+                Console.WriteLine($"  Build ID:    {run.PlatformId}");
+                Console.WriteLine($"  Number:      {run.Name ?? "unknown"}");
+                Console.WriteLine($"  Status:      {run.Status ?? "unknown"}");
+                Console.WriteLine($"  Result:      {run.Result ?? "pending"}");
+                Console.WriteLine($"  Build URL:   {run.Url ?? "not available"}");
 
                 // Attempt to download and display log content
                 try
                 {
-                    var logText = await client.GetBuildLogsAsync(project, build.Id);
-                    if (!string.IsNullOrWhiteSpace(logText))
+                    if (int.TryParse(run.PlatformId, out var intId))
                     {
-                        Console.WriteLine();
-                        ConsoleHelper.WriteLine("--- Log Content ---", ConsoleColor.Yellow);
-                        Console.WriteLine(logText.TrimEnd());
+                        var logText = await client.GetPipelineRunLogsAsync(project, intId);
+                        if (!string.IsNullOrWhiteSpace(logText))
+                        {
+                            Console.WriteLine();
+                            ConsoleHelper.WriteLine("--- Log Content ---", ConsoleColor.Yellow);
+                            Console.WriteLine(logText.TrimEnd());
+                        }
+                        else
+                        {
+                            Console.WriteLine("[No log content available or failed to download]");
+                        }
                     }
                     else
                     {
-                        Console.WriteLine("[No log content available or failed to download]");
+                        Console.WriteLine("[No valid build id available to download logs]");
                     }
                 }
                 catch (Exception ex)

--- a/Sdo/Commands/PipelineCommand.cs
+++ b/Sdo/Commands/PipelineCommand.cs
@@ -207,12 +207,25 @@ namespace Sdo.Commands
         private void AddUpdateCommand(Option<bool> verboseOption)
         {
             var updateCommand = new System.CommandLine.Command("update", "Update pipeline configuration");
+            var fileOption = new Option<string?>("--file") { Description = "Path to pipeline/workflow YAML file to update in repository" };
+            var pipelineOption = new Option<string?>("--pipeline") { Description = "Pipeline/workflow ID or name (optional)" };
+            var messageOption = new Option<string?>("--message") { Description = "Commit message to use when updating the file" };
+            var branchOption = new Option<string?>("--branch") { Description = "Branch to push the update to" };
+
+            updateCommand.Add(fileOption);
+            updateCommand.Add(pipelineOption);
+            updateCommand.Add(messageOption);
+            updateCommand.Add(branchOption);
             updateCommand.Add(verboseOption);
 
             updateCommand.SetAction(async (parseResult) =>
             {
+                var file = parseResult.GetValue(fileOption);
+                var pipeline = parseResult.GetValue(pipelineOption);
+                var message = parseResult.GetValue(messageOption);
+                var branch = parseResult.GetValue(branchOption);
                 var verbose = parseResult.GetValue(verboseOption);
-                return await UpdatePipeline(verbose);
+                return await UpdatePipeline(file, pipeline, message, branch, verbose);
             });
 
             Subcommands.Add(updateCommand);
@@ -779,15 +792,18 @@ namespace Sdo.Commands
                     }
 
                     ConsoleHelper.WriteLine($"[OK] Build queued (ID: {buildId})", ConsoleColor.Green);
-                    var build = await client.GetBuildAsync(repoInfo.Project, buildId);
-                    if (build != null)
+
+                    // Prefer neutral pipeline run wrapper
+                    var run = await client.GetPipelineRunAsync(repoInfo.Project, buildId);
+                    if (run != null)
                     {
-                        var run = build.ToPipelineRun();
-                        if (run != null)
-                        {
-                            Console.WriteLine($"  Pipeline: {run.Name}  Build Number: {run.Name}  Status: {run.Status}");
-                        }
-                        else
+                        Console.WriteLine($"  Pipeline: {run.Name}  Build Number: {run.Name}  Status: {run.Status}");
+                    }
+                    else
+                    {
+                        // Fallback to raw build DTO if wrapper failed to convert
+                        var build = await client.GetBuildAsync(repoInfo.Project, buildId);
+                        if (build != null)
                         {
                             Console.WriteLine($"  Pipeline: {build.Definition?.Name}  Build Number: {build.BuildNumber}  Status: {build.Status}");
                         }
@@ -1193,7 +1209,8 @@ namespace Sdo.Commands
 
                 using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
                 {
-                    var pipelines = await client.ListPipelinesAsync(project);
+                    // Use neutral pipeline definitions API
+                    var pipelines = await client.ListPipelineDefinitionsAsync(project);
 
                     if (pipelines == null || pipelines.Count == 0)
                     {
@@ -1223,8 +1240,8 @@ namespace Sdo.Commands
                             name = name.Substring(0, 35) + "...";
                         }
 
-                        var lastBuild = pipeline.ModifiedDate.HasValue ? pipeline.ModifiedDate.Value.ToString("g") : "Never";
-                        Console.WriteLine($"{name,-40} {lastBuild,-20} {pipeline.QueueStatus}");
+                        var lastBuild = pipeline.UpdatedAt.HasValue ? pipeline.UpdatedAt.Value.ToString("g") : "Never";
+                        Console.WriteLine($"{name,-40} {lastBuild,-20} {pipeline.State}");
                     }
                 }
 
@@ -1735,7 +1752,7 @@ namespace Sdo.Commands
             }
         }
 
-        private async Task<int> UpdatePipeline(bool verbose)
+        private async Task<int> UpdatePipeline(string? filePath, string? pipelineId, string? commitMessage, string? branch, bool verbose)
         {
             try
             {
@@ -1750,42 +1767,181 @@ namespace Sdo.Commands
                     return 1;
                 }
 
-                if (platform == Platform.GitHub)
+                // If no file provided, fall back to guidance (non-destructive)
+                if (string.IsNullOrWhiteSpace(filePath))
                 {
-                    if (verbose) DisplayGitHubMapping("workflow update");
-                    ConsoleHelper.WriteLine("[INFO] To update GitHub workflow, modify the .github/workflows/<file>.yml and commit/push the change.", ConsoleColor.Yellow);
-                    Console.WriteLine("  Steps:");
-                    Console.WriteLine("    1. Edit .github/workflows/<workflow-file>.yml");
-                    Console.WriteLine("    2. git add <file> && git commit -m 'Update workflow' && git push");
-                    return 0;
-                }
-                else if (platform == Platform.AzureDevOps)
-                {
-                    if (string.IsNullOrEmpty(repoInfo.Organization) || string.IsNullOrEmpty(repoInfo.Project))
+                    if (platform == Platform.GitHub)
                     {
-                        ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
-                        return 1;
+                        if (verbose) DisplayGitHubMapping("workflow update");
+                        ConsoleHelper.WriteLine("[INFO] To update GitHub workflow, modify the .github/workflows/<file>.yml and commit/push the change.", ConsoleColor.Yellow);
+                        Console.WriteLine("  Steps:");
+                        Console.WriteLine("    1. Edit .github/workflows/<workflow-file>.yml");
+                        Console.WriteLine("    2. git add <file> && git commit -m 'Update workflow' && git push");
+                        return 0;
+                    }
+                    else if (platform == Platform.AzureDevOps)
+                    {
+                        if (verbose) DisplayAzureDevOpsMapping("pipeline update");
+                        ConsoleHelper.WriteLine("[INFO] To update an Azure DevOps pipeline, update the YAML in your repository and commit/push. Alternatively, update the pipeline definition via Azure DevOps REST API.", ConsoleColor.Yellow);
+                        Console.WriteLine("  Steps:");
+                        Console.WriteLine("    1. Edit azure-pipelines/<pipeline>.yml");
+                        Console.WriteLine("    2. git add <file> && git commit -m 'Update pipeline' && git push");
+                        Console.WriteLine("    3. If pipeline uses pipeline definition in UI, update via Azure DevOps portal or REST API");
+                        return 0;
                     }
 
-                    var pat = AzureDevOpsCredentials.GetTokenOrDefault();
-                    if (string.IsNullOrEmpty(pat))
-                    {
-                        ConsoleHelper.WriteError("X Azure DevOps authentication required.");
-                        Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
-                        return 1;
-                    }
-
-                    using var client = new Sdo.Services.AzureDevOpsClient(pat, repoInfo.Organization, repoInfo.Project);
-                    ConsoleHelper.WriteLine("[INFO] To update an Azure DevOps pipeline, update the YAML in your repository and commit/push. Alternatively, update the pipeline definition via Azure DevOps REST API.", ConsoleColor.Yellow);
-                    Console.WriteLine("  Steps:");
-                    Console.WriteLine("    1. Edit azure-pipelines/<pipeline>.yml");
-                    Console.WriteLine("    2. git add <file> && git commit -m 'Update pipeline' && git push");
-                    Console.WriteLine("    3. If pipeline uses pipeline definition in UI, update via Azure DevOps portal or REST API");
-                    return 0;
+                    ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                    return 1;
                 }
 
-                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
-                return 1;
+                // Validate file
+                if (!File.Exists(filePath))
+                {
+                    ConsoleHelper.WriteError($"X File not found: {filePath}");
+                    return 1;
+                }
+
+                var ext = Path.GetExtension(filePath).ToLowerInvariant();
+                if (ext != ".yml" && ext != ".yaml")
+                {
+                    ConsoleHelper.WriteError("X Pipeline definition file must be YAML (.yml or .yaml)");
+                    return 1;
+                }
+
+                var message = string.IsNullOrWhiteSpace(commitMessage) ? (platform == Platform.GitHub ? "Update workflow via sdo" : "Update pipeline via sdo") : commitMessage;
+
+                // Stage, commit, push locally. This approach updates YAML-backed pipelines for both GitHub and Azure DevOps.
+                if (verbose) Console.WriteLine($"[INFO] Staging file: {filePath}");
+
+                var addPsi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"add \"{filePath}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using (var addProc = System.Diagnostics.Process.Start(addPsi))
+                {
+                    if (addProc != null)
+                    {
+                        var aOut = await addProc.StandardOutput.ReadToEndAsync();
+                        var aErr = await addProc.StandardError.ReadToEndAsync();
+                        await addProc.WaitForExitAsync();
+                        if (addProc.ExitCode != 0)
+                        {
+                            ConsoleHelper.WriteError($"X git add failed: {aErr.Trim()}");
+                            return 1;
+                        }
+                    }
+                }
+
+                var commitPsi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"commit -m \"{message.Replace("\"", "'\"")}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using (var commitProc = System.Diagnostics.Process.Start(commitPsi))
+                {
+                    if (commitProc != null)
+                    {
+                        var cOut = await commitProc.StandardOutput.ReadToEndAsync();
+                        var cErr = await commitProc.StandardError.ReadToEndAsync();
+                        await commitProc.WaitForExitAsync();
+                        if (commitProc.ExitCode != 0)
+                        {
+                            // If there's nothing to commit, continue
+                            if (cOut.Contains("nothing to commit", StringComparison.OrdinalIgnoreCase) || cErr.Contains("nothing to commit", StringComparison.OrdinalIgnoreCase))
+                            {
+                                Console.WriteLine("[INFO] No changes to commit.");
+                            }
+                            else
+                            {
+                                ConsoleHelper.WriteError($"X git commit failed: {cErr.Trim()}");
+                                return 1;
+                            }
+                        }
+                    }
+                }
+
+                var pushArgs = string.IsNullOrWhiteSpace(branch) ? "push" : $"push origin {branch}";
+                var pushPsi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = pushArgs,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using (var pushProc = System.Diagnostics.Process.Start(pushPsi))
+                {
+                    if (pushProc != null)
+                    {
+                        var pOut = await pushProc.StandardOutput.ReadToEndAsync();
+                        var pErr = await pushProc.StandardError.ReadToEndAsync();
+                        await pushProc.WaitForExitAsync();
+                        if (pushProc.ExitCode != 0)
+                        {
+                            ConsoleHelper.WriteError($"X git push failed: {pErr.Trim()}");
+                            return 1;
+                        }
+                    }
+                }
+
+                ConsoleHelper.WriteLine("[OK] Pipeline/workflow file updated and pushed.", ConsoleColor.Green);
+
+                // Attempt API-driven update for Azure DevOps definitions when a pipeline id was provided
+                if (platform == Platform.AzureDevOps && !string.IsNullOrWhiteSpace(pipelineId))
+                {
+                    if (int.TryParse(pipelineId, out var defId))
+                    {
+                        var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                        if (!string.IsNullOrEmpty(pat))
+                        {
+                            var org = repoInfo?.Organization ?? repoInfo?.Owner ?? string.Empty;
+                            if (string.IsNullOrWhiteSpace(org) || string.IsNullOrWhiteSpace(repoInfo?.Project))
+                            {
+                                ConsoleHelper.WriteLine("[WARN] Unable to determine Azure DevOps organization/project; skipping REST update.", ConsoleColor.Yellow);
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    using var client = new Sdo.Services.AzureDevOpsClient(pat, org, repoInfo.Project);
+                                    var ok = await client.UpdatePipelineDefinitionYamlAsync(repoInfo.Project, defId, filePath!);
+                                    if (ok)
+                                    {
+                                        ConsoleHelper.WriteLine("[OK] Azure DevOps pipeline definition updated via REST API.", ConsoleColor.Green);
+                                    }
+                                    else
+                                    {
+                                        ConsoleHelper.WriteLine($"[WARN] Azure DevOps REST update failed: {client.LastError}", ConsoleColor.Yellow);
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    ConsoleHelper.WriteLine($"[WARN] Exception calling Azure DevOps REST update: {ex.Message}", ConsoleColor.Yellow);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            ConsoleHelper.WriteLine("[INFO] AZURE_DEVOPS_PAT not found; skipping REST update.", ConsoleColor.Yellow);
+                        }
+                    }
+                }
+
+                // Note: For Azure DevOps UI-backed definitions, further REST API updates may be required. Consider adding UpdatePipelineDefinitionAsync in AzureDevOpsClient when needed.
+                return 0;
             }
             catch (Exception ex)
             {

--- a/Sdo/Commands/PipelineCommand.cs
+++ b/Sdo/Commands/PipelineCommand.cs
@@ -1,0 +1,1273 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+//
+// PipelineCommand.cs
+//
+// Command handler for pipeline/workflow management operations.
+// Supports both GitHub Actions workflows and Azure DevOps pipelines.
+
+using System.CommandLine;
+using Nbuild.Helpers;
+using Sdo.Interfaces;
+using Sdo.Services;
+
+namespace Sdo.Commands
+{
+    /// <summary>
+    /// Command handler for pipeline/workflow management operations.
+    /// </summary>
+    public class PipelineCommand : System.CommandLine.Command
+    {
+        private readonly PlatformService _platformDetector;
+        private readonly Sdo.Mapping.IMappingGenerator _mappingGenerator;
+        private readonly Sdo.Mapping.IMappingPresenter _mappingPresenter;
+
+        /// <summary>
+        /// Initializes a new instance of the PipelineCommand class.
+        /// </summary>
+        /// <param name="verboseOption">Option for verbose output.</param>
+        public PipelineCommand(Option<bool> verboseOption, Sdo.Mapping.IMappingGenerator? mappingGenerator = null, Sdo.Mapping.IMappingPresenter? mappingPresenter = null)
+            : base("pipeline", "Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)")
+        {
+            _platformDetector = new PlatformService();
+            _mappingGenerator = mappingGenerator ?? new Sdo.Mapping.MappingGenerator();
+            _mappingPresenter = mappingPresenter ?? new Sdo.Mapping.ConsoleMappingPresenter();
+
+            // Add subcommands in alphabetical order
+            AddCreateCommand(verboseOption);
+            AddDeleteCommand(verboseOption);
+            AddLastbuildCommand(verboseOption);
+            AddListCommand(verboseOption);
+            AddLogsCommand(verboseOption);
+            AddRunCommand(verboseOption);
+            AddShowCommand(verboseOption);
+            AddStatusCommand(verboseOption);
+            AddUpdateCommand(verboseOption);
+        }
+
+        private void AddCreateCommand(Option<bool> verboseOption)
+        {
+            var createCommand = new System.CommandLine.Command("create", "Create a new pipeline/workflow from YAML definition file");
+            var fileArg = new Argument<string>("file-path") { Description = "Path to pipeline/workflow YAML definition file" };
+
+            createCommand.Add(fileArg);
+            createCommand.Add(verboseOption);
+
+            createCommand.SetAction(async (parseResult) =>
+            {
+                var filePath = parseResult.GetValue(fileArg);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await CreatePipeline(filePath!, verbose);
+            });
+
+            Subcommands.Add(createCommand);
+        }
+
+        private void AddDeleteCommand(Option<bool> verboseOption)
+        {
+            var deleteCommand = new System.CommandLine.Command("delete", "Delete a pipeline/workflow");
+            var pipelineIdArg = new Argument<string?>("pipeline-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Pipeline/workflow ID or name (optional, uses current repo if not provided)" };
+            var forceOption = new Option<bool>("--force") { Description = "Skip confirmation prompt" };
+
+            deleteCommand.Add(pipelineIdArg);
+            deleteCommand.Add(forceOption);
+            deleteCommand.Add(verboseOption);
+
+            deleteCommand.SetAction(async (parseResult) =>
+            {
+                var pipelineId = parseResult.GetValue(pipelineIdArg);
+                var force = parseResult.GetValue(forceOption);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await DeletePipeline(pipelineId, force, verbose);
+            });
+
+            Subcommands.Add(deleteCommand);
+        }
+
+        private void AddLastbuildCommand(Option<bool> verboseOption)
+        {
+            var lastbuildCommand = new System.CommandLine.Command("lastbuild", "Show last build/run for a pipeline");
+            var pipelineNameArg = new Argument<string?>("pipeline-name") { Arity = ArgumentArity.ZeroOrOne, Description = "Pipeline name (optional, uses current repo if not provided)" };
+
+            lastbuildCommand.Add(pipelineNameArg);
+            lastbuildCommand.Add(verboseOption);
+
+            lastbuildCommand.SetAction(async (parseResult) =>
+            {
+                var pipelineName = parseResult.GetValue(pipelineNameArg);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await LastBuild(pipelineName, verbose);
+            });
+
+            Subcommands.Add(lastbuildCommand);
+        }
+
+        private void AddListCommand(Option<bool> verboseOption)
+        {
+            var listCommand = new System.CommandLine.Command("list", "List pipelines/workflows");
+            var repoOption = new Option<string?>("--repo") { Description = "Filter by repository name" };
+            var allOption = new Option<bool>("--all") { Description = "Show all pipelines in the project" };
+
+            listCommand.Add(repoOption);
+            listCommand.Add(allOption);
+            listCommand.Add(verboseOption);
+
+            listCommand.SetAction(async (parseResult) =>
+            {
+                var repo = parseResult.GetValue(repoOption);
+                var showAll = parseResult.GetValue(allOption);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await ListPipelines(repo, showAll, verbose);
+            });
+
+            Subcommands.Add(listCommand);
+        }
+
+        private void AddLogsCommand(Option<bool> verboseOption)
+        {
+            var logsCommand = new System.CommandLine.Command("logs", "Retrieve pipeline execution logs");
+            var buildIdArg = new Argument<int?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
+            var buildIdOption = new Option<int?>("--build-id") { Description = "Build/run ID" };
+
+            logsCommand.Add(buildIdArg);
+            logsCommand.Add(buildIdOption);
+            logsCommand.Add(verboseOption);
+
+            logsCommand.SetAction(async (parseResult) =>
+            {
+                var buildId = parseResult.GetValue(buildIdArg) ?? parseResult.GetValue(buildIdOption);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await GetLogs(buildId, verbose);
+            });
+
+            Subcommands.Add(logsCommand);
+        }
+
+        private void AddRunCommand(Option<bool> verboseOption)
+        {
+            var runCommand = new System.CommandLine.Command("run", "Execute/trigger a pipeline");
+            var pipelineNameArg = new Argument<string?>("pipeline-name") { Arity = ArgumentArity.ZeroOrOne, Description = "Pipeline name (optional, uses current repo if not provided)" };
+            var branchOption = new Option<string>("--branch") { Aliases = { "-b" }, Description = "Branch to run the pipeline on" };
+
+            runCommand.Add(pipelineNameArg);
+            runCommand.Add(branchOption);
+            runCommand.Add(verboseOption);
+
+            runCommand.SetAction(async (parseResult) =>
+            {
+                var pipelineName = parseResult.GetValue(pipelineNameArg);
+                var branch = parseResult.GetValue(branchOption);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await RunPipeline(pipelineName, branch!, verbose);
+            });
+
+            Subcommands.Add(runCommand);
+        }
+
+        private void AddShowCommand(Option<bool> verboseOption)
+        {
+            var showCommand = new System.CommandLine.Command("show", "Display pipeline/workflow details");
+            showCommand.Add(verboseOption);
+
+            showCommand.SetAction(async (parseResult) =>
+            {
+                var verbose = parseResult.GetValue(verboseOption);
+                return await ShowPipeline(verbose);
+            });
+
+            Subcommands.Add(showCommand);
+        }
+
+        private void AddStatusCommand(Option<bool> verboseOption)
+        {
+            var statusCommand = new System.CommandLine.Command("status", "Query pipeline build/run status");
+            var buildIdArg = new Argument<int?>("build-id") { Arity = ArgumentArity.ZeroOrOne, Description = "Build/run ID (optional, shows latest if not provided)" };
+
+            statusCommand.Add(buildIdArg);
+            statusCommand.Add(verboseOption);
+
+            statusCommand.SetAction(async (parseResult) =>
+            {
+                var buildId = parseResult.GetValue(buildIdArg);
+                var verbose = parseResult.GetValue(verboseOption);
+                return await GetStatus(buildId, verbose);
+            });
+
+            Subcommands.Add(statusCommand);
+        }
+
+        private void AddUpdateCommand(Option<bool> verboseOption)
+        {
+            var updateCommand = new System.CommandLine.Command("update", "Update pipeline configuration");
+            updateCommand.Add(verboseOption);
+
+            updateCommand.SetAction(async (parseResult) =>
+            {
+                var verbose = parseResult.GetValue(verboseOption);
+                return await UpdatePipeline(verbose);
+            });
+
+            Subcommands.Add(updateCommand);
+        }
+
+        #region Command Handlers
+
+        private async Task<int> CreatePipeline(string filePath, bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Creating pipeline/workflow from definition file...");
+
+                // Validate file exists
+                if (!File.Exists(filePath))
+                {
+                    ConsoleHelper.WriteError($"X File not found: {filePath}");
+                    return 1;
+                }
+
+                var fileExtension = Path.GetExtension(filePath).ToLowerInvariant();
+                if (fileExtension != ".yml" && fileExtension != ".yaml")
+                {
+                    ConsoleHelper.WriteError("X Pipeline definition file must be in YAML format (.yml or .yaml)");
+                    return 1;
+                }
+
+                if (verbose) Console.WriteLine($"[INFO] Reading pipeline definition from {filePath}...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("workflow create");
+                    }
+                    return await CreateGitHubWorkflow(repoInfo.Owner, repoInfo.Repo, filePath, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline create");
+                    }
+                    return await CreateAzureDevOpsPipeline(repoInfo.Organization, repoInfo.Project, filePath, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error creating pipeline: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> DeletePipeline(string? pipelineId, bool force, bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Deleting pipeline/workflow from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("workflow delete");
+                    }
+                    return await DeleteGitHubWorkflow(repoInfo.Owner, repoInfo.Repo, pipelineId, force, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline delete");
+                    }
+                    return await DeleteAzureDevOpsPipeline(repoInfo.Organization, repoInfo.Project, pipelineId, force, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error deleting pipeline: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> LastBuild(string? pipelineName, bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Retrieving last build/run information from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("workflow lastbuild");
+                    }
+                    return await GetGitHubLastRun(repoInfo.Owner, repoInfo.Repo, pipelineName, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline lastbuild");
+                    }
+                    return await GetAzureDevOpsLastBuild(repoInfo.Organization, repoInfo.Project, pipelineName, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error retrieving last build: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> ListPipelines(string? repo, bool showAll, bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Listing pipeline/workflow information from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("workflow list");
+                    }
+                    return await ListGitHubWorkflows(repoInfo.Owner, repoInfo.Repo, repo, showAll, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline list");
+                    }
+                    return await ListAzureDevOpsPipelines(repoInfo.Organization, repoInfo.Project, repo, showAll, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error listing pipelines: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> ListGitHubWorkflows(string owner, string repo, string? filterRepo, bool showAll, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                string filterDisplay = showAll ? "all workflows" : "workflows for this repository";
+                if (!string.IsNullOrEmpty(filterRepo))
+                {
+                    filterDisplay = $"workflows for repository: {filterRepo}";
+                }
+
+                if (verbose)
+                {
+                    Console.WriteLine($"Workflows location: .github/workflows/");
+                    Console.WriteLine($"Filter: {filterDisplay}");
+                }
+
+                // Fetch workflows from GitHub API
+                using (var client = new Sdo.Services.GitHubClient())
+                {
+                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+
+                    if (workflows == null || workflows.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    // Apply repository name filter if specified
+                    if (!string.IsNullOrEmpty(filterRepo))
+                    {
+                        workflows = workflows.Where(w =>
+                            (w.Name ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase) ||
+                            (w.Path ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase)
+                        ).ToList();
+
+                        if (workflows.Count == 0)
+                        {
+                            ConsoleHelper.WriteLine($"No workflows found matching repository filter: {filterRepo}", ConsoleColor.Yellow);
+                            return 0;
+                        }
+                    }
+
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Workflows in this repository:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+                    Console.WriteLine($"{"Name",-40} {"State",-10} {"ID"}");
+                    Console.WriteLine(new string('-', 60));
+
+                    foreach (var workflow in workflows)
+                    {
+                        var name = workflow.Name ?? "Unnamed Workflow";
+                        if (name.Length > 38)
+                        {
+                            name = name.Substring(0, 35) + "...";
+                        }
+
+                        Console.WriteLine($"{name,-40} {workflow.State,-10} {workflow.Id}");
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to list GitHub workflows: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> ListAzureDevOpsPipelines(string? organization, string? project, string? filterRepo, bool showAll, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+
+                string filterDisplay = showAll ? "all pipelines" : "pipelines for this project";
+                if (!string.IsNullOrEmpty(filterRepo))
+                {
+                    filterDisplay = $"pipelines for repository: {filterRepo}";
+                }
+
+                if (verbose)
+                {
+                    Console.WriteLine($"Pipeline location: azure-pipelines/");
+                    Console.WriteLine($"Filter: {filterDisplay}");
+                }
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                // Get Azure DevOps credentials
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
+                {
+                    var pipelines = await client.ListPipelinesAsync(project);
+
+                    if (pipelines == null || pipelines.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No pipelines found in this project.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    // Apply repository name filter if specified
+                    if (!string.IsNullOrEmpty(filterRepo))
+                    {
+                        pipelines = pipelines.Where(p =>
+                            (p.Name ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase) ||
+                            (p.Path ?? "").Contains(filterRepo, StringComparison.OrdinalIgnoreCase)
+                        ).ToList();
+
+                        if (pipelines.Count == 0)
+                        {
+                            ConsoleHelper.WriteLine($"No pipelines found matching repository filter: {filterRepo}", ConsoleColor.Yellow);
+                            return 0;
+                        }
+                    }
+
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Pipelines in this project:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+                    Console.WriteLine($"{"Name",-40} {"Status",-15} {"ID"}");
+                    Console.WriteLine(new string('-', 60));
+
+                    foreach (var pipeline in pipelines)
+                    {
+                        var name = pipeline.Name ?? "Unnamed Pipeline";
+                        if (name.Length > 38)
+                        {
+                            name = name.Substring(0, 35) + "...";
+                        }
+
+                        var status = pipeline.QueueStatus ?? "unknown";
+                        Console.WriteLine($"{name,-40} {status,-15} {pipeline.Id}");
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to list Azure DevOps pipelines: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetLogs(int? buildId, bool verbose)
+        {
+            Console.WriteLine("X Pipeline logs command not yet implemented");
+            return 1;
+        }
+
+        private async Task<int> RunPipeline(string? pipelineName, string branch, bool verbose)
+        {
+            Console.WriteLine("X Pipeline run command not yet implemented");
+            return 1;
+        }
+
+        private async Task<int> ShowPipeline(bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Retrieving pipeline information from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("workflow");
+                    }
+                    return await ShowGitHubWorkflow(repoInfo.Owner, repoInfo.Repo, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline show");
+                    }
+                    return await ShowAzureDevOpsPipeline(repoInfo.Organization, repoInfo.Project, repoInfo.Repository, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error showing pipeline: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> ShowGitHubWorkflow(string owner, string repo, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"Workflows location: .github/workflows/");
+                }
+
+                // Fetch workflows from GitHub API
+                using (var client = new Sdo.Services.GitHubClient())
+                {
+                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+
+                    if (workflows == null || workflows.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Workflows in this repository:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+
+                    foreach (var workflow in workflows)
+                    {
+                        var stateColor = workflow.State == "active" ? ConsoleColor.Green : ConsoleColor.Yellow;
+                        ConsoleHelper.WriteLine($"  • {workflow.Name ?? "Unnamed Workflow"}", stateColor);
+                        Console.WriteLine($"    State: {workflow.State}");
+                        Console.WriteLine($"    ID: {workflow.Id}");
+                        if (!string.IsNullOrEmpty(workflow.Path))
+                        {
+                            Console.WriteLine($"    Path: {workflow.Path}");
+                        }
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to show GitHub workflows: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> ShowAzureDevOpsPipeline(string? organization, string? project, string? repository, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+                ConsoleHelper.WriteLine($"✓ Repository: {repository ?? "unknown"}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"Pipeline location: azure-pipelines/");
+                }
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                // Fetch pipelines from Azure DevOps API
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
+                {
+                    var pipelines = await client.ListPipelinesAsync(project);
+
+                    if (pipelines == null || pipelines.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No pipelines found in this project.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Pipelines in this project:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+
+                    foreach (var pipeline in pipelines)
+                    {
+                        var statusColor = pipeline.QueueStatus == "enabled" ? ConsoleColor.Green : ConsoleColor.Yellow;
+                        ConsoleHelper.WriteLine($"  • {pipeline.Name ?? "Unnamed Pipeline"}", statusColor);
+                        Console.WriteLine($"    ID: {pipeline.Id}");
+                        Console.WriteLine($"    Status: {pipeline.QueueStatus}");
+                        if (!string.IsNullOrEmpty(pipeline.Path))
+                        {
+                            Console.WriteLine($"    Path: {pipeline.Path}");
+                        }
+                        if (pipeline.CreatedDate.HasValue)
+                        {
+                            Console.WriteLine($"    Created: {pipeline.CreatedDate:g}");
+                        }
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to show Azure DevOps pipelines: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> DeleteGitHubWorkflow(string owner, string repo, string? workflowId, bool force, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Deleting workflow from {owner}/{repo}");
+                    Console.WriteLine($"Workflows location: .github/workflows/");
+                }
+
+                if (string.IsNullOrEmpty(workflowId))
+                {
+                    ConsoleHelper.WriteError("X Workflow ID or name is required");
+                    return 1;
+                }
+
+                if (!force)
+                {
+                    Console.WriteLine();
+                    Console.Write($"Delete workflow '{workflowId}'? (y/N): ");
+                    var response = Console.ReadLine();
+                    if (response?.ToLower() != "y")
+                    {
+                        Console.WriteLine("Delete cancelled.");
+                        return 0;
+                    }
+                }
+
+                // For GitHub, workflow deletion requires disabling the workflow file in the repository
+                // This would typically be done via a commit that removes or disables the workflow
+                ConsoleHelper.WriteLine($"[OK] Workflow deletion would be processed", ConsoleColor.Green);
+                Console.WriteLine();
+                ConsoleHelper.WriteLine($"To delete this workflow:", ConsoleColor.Cyan);
+                Console.WriteLine($"  1. Delete or rename the {workflowId}.yml file from .github/workflows/");
+                Console.WriteLine($"  2. Commit and push the change");
+                Console.WriteLine($"  3. Workflow will be removed from GitHub Actions");
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to delete GitHub workflow: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> DeleteAzureDevOpsPipeline(string? organization, string? project, string? pipelineId, bool force, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Deleting pipeline from {organization}/{project}");
+                    Console.WriteLine($"Pipeline location: azure-pipelines/");
+                }
+
+                if (string.IsNullOrEmpty(pipelineId))
+                {
+                    ConsoleHelper.WriteError("X Pipeline ID or name is required");
+                    return 1;
+                }
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                // Get Azure DevOps credentials
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                if (!force)
+                {
+                    Console.WriteLine();
+                    Console.Write($"Delete pipeline '{pipelineId}'? (y/N): ");
+                    var response = Console.ReadLine();
+                    if (response?.ToLower() != "y")
+                    {
+                        Console.WriteLine("Delete cancelled.");
+                        return 0;
+                    }
+                }
+
+                using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
+                {
+                    // For now, show what would happen
+                    // In a real implementation, we would call DeletePipelineAsync
+                    ConsoleHelper.WriteLine($"[OK] Pipeline deletion would be processed", ConsoleColor.Green);
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine($"Details:", ConsoleColor.Cyan);
+                    Console.WriteLine($"  Pipeline ID: {pipelineId}");
+                    Console.WriteLine($"  Project: {project}");
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to delete Azure DevOps pipeline: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetGitHubLastRun(string owner, string repo, string? workflowName, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Retrieving last workflow run");
+                    Console.WriteLine($"Workflows location: .github/workflows/");
+                }
+
+                // Fetch workflows from GitHub API first
+                using (var client = new Sdo.Services.GitHubClient())
+                {
+                    var workflows = await client.ListWorkflowsAsync(owner, repo);
+
+                    if (workflows == null || workflows.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No workflows found in this repository.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    // For now, show the workflows available
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Latest workflow runs:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+                    Console.WriteLine($"{"Workflow Name",-40} {"Last Run",-20} {"Status"}");
+                    Console.WriteLine(new string('-', 70));
+
+                    foreach (var workflow in workflows.Take(5))
+                    {
+                        var name = workflow.Name ?? "Unnamed Workflow";
+                        if (name.Length > 38)
+                        {
+                            name = name.Substring(0, 35) + "...";
+                        }
+
+                        var lastRun = workflow.UpdatedAt.HasValue ? workflow.UpdatedAt.Value.ToString("g") : "Never";
+                        Console.WriteLine($"{name,-40} {lastRun,-20} {workflow.State}");
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get GitHub last run: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetAzureDevOpsLastBuild(string? organization, string? project, string? pipelineName, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Retrieving last build information");
+                    Console.WriteLine($"Pipeline location: azure-pipelines/");
+                }
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                // Get Azure DevOps credentials
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
+                {
+                    var pipelines = await client.ListPipelinesAsync(project);
+
+                    if (pipelines == null || pipelines.Count == 0)
+                    {
+                        ConsoleHelper.WriteLine("No pipelines found in this project.", ConsoleColor.Yellow);
+                        return 0;
+                    }
+
+                    // Filter by pipeline name if provided
+                    if (!string.IsNullOrEmpty(pipelineName))
+                    {
+                        pipelines = pipelines.Where(p =>
+                            (p.Name ?? "").Contains(pipelineName, StringComparison.OrdinalIgnoreCase)
+                        ).ToList();
+                    }
+
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine("✓ Recent builds:", ConsoleColor.Cyan);
+                    Console.WriteLine();
+                    Console.WriteLine($"{"Pipeline Name",-40} {"Last Build",-20} {"Status"}");
+                    Console.WriteLine(new string('-', 70));
+
+                    foreach (var pipeline in pipelines.Take(5))
+                    {
+                        var name = pipeline.Name ?? "Unnamed Pipeline";
+                        if (name.Length > 38)
+                        {
+                            name = name.Substring(0, 35) + "...";
+                        }
+
+                        var lastBuild = pipeline.ModifiedDate.HasValue ? pipeline.ModifiedDate.Value.ToString("g") : "Never";
+                        Console.WriteLine($"{name,-40} {lastBuild,-20} {pipeline.QueueStatus}");
+                    }
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get Azure DevOps last build: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> CreateGitHubWorkflow(string owner, string repo, string filePath, bool verbose)
+        {
+            try
+            {
+                var fileName = Path.GetFileName(filePath);
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Reading workflow definition from {filePath}");
+                    Console.WriteLine($"Workflows location: .github/workflows/");
+                }
+
+                // Validate file exists
+                if (!File.Exists(filePath))
+                {
+                    ConsoleHelper.WriteError($"X File not found: {filePath}");
+                    return 1;
+                }
+
+                var yamlContent = await File.ReadAllTextAsync(filePath);
+                if (string.IsNullOrWhiteSpace(yamlContent))
+                {
+                    ConsoleHelper.WriteError("X YAML file is empty");
+                    return 1;
+                }
+
+                // Use GitHub API to validate and prepare workflow creation
+                using var githubClient = new GitHubClient();
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Validating workflow with GitHub API...");
+                }
+
+                var success = await githubClient.CreateWorkflowAsync(owner, repo, fileName, filePath);
+                if (!success)
+                {
+                    ConsoleHelper.WriteError($"X Workflow validation failed: Repository {owner}/{repo} not found or not accessible");
+                    return 1;
+                }
+
+                // Workflow validation passed
+                var workflowPath = Path.Combine(".github", "workflows", fileName);
+                ConsoleHelper.WriteLine($"[OK] Workflow definition validated successfully", ConsoleColor.Green);
+                Console.WriteLine();
+                ConsoleHelper.WriteLine($"Workflow Details:", ConsoleColor.Cyan);
+                Console.WriteLine($"  Repository: {owner}/{repo}");
+                Console.WriteLine($"  Filename:   {fileName}");
+                Console.WriteLine($"  Path:       {workflowPath}");
+                Console.WriteLine();
+                ConsoleHelper.WriteLine($"To create and activate this workflow:", ConsoleColor.Cyan);
+                Console.WriteLine($"  1. Copy {fileName} to .github/workflows/ in your repository");
+                Console.WriteLine($"  2. Commit the file: git add {workflowPath}");
+                Console.WriteLine($"  3. Commit changes: git commit -m 'Add GitHub Actions workflow'");
+                Console.WriteLine($"  4. Push to repository: git push");
+                Console.WriteLine($"  5. Workflow will be activated in GitHub Actions");
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to create GitHub workflow: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> CreateAzureDevOpsPipeline(string? organization, string? project, string filePath, bool verbose)
+        {
+            try
+            {
+                var fileName = Path.GetFileName(filePath);
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+
+                if (verbose)
+                {
+                    Console.WriteLine($"[INFO] Reading pipeline definition from {filePath}");
+                    Console.WriteLine($"Pipeline location: azure-pipelines/");
+                }
+
+                if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+                {
+                    ConsoleHelper.WriteError("X Organization and project are required for Azure DevOps");
+                    return 1;
+                }
+
+                // Validate file exists
+                if (!File.Exists(filePath))
+                {
+                    ConsoleHelper.WriteError($"X File not found: {filePath}");
+                    return 1;
+                }
+
+                var yamlContent = await File.ReadAllTextAsync(filePath);
+                if (string.IsNullOrWhiteSpace(yamlContent))
+                {
+                    ConsoleHelper.WriteError("X YAML file is empty");
+                    return 1;
+                }
+
+                // Get Azure DevOps credentials
+                var pat = AzureDevOpsCredentials.GetTokenOrDefault();
+                if (string.IsNullOrEmpty(pat))
+                {
+                    ConsoleHelper.WriteError("X Azure DevOps authentication required.");
+                    Console.WriteLine("Please set AZURE_DEVOPS_PAT environment variable or run: sdo.net auth azdo");
+                    return 1;
+                }
+
+                using (var client = new Sdo.Services.AzureDevOpsClient(pat, organization, project))
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine($"[INFO] Creating pipeline with Azure DevOps API...");
+                    }
+
+                    var pipelineFileName = Path.GetFileNameWithoutExtension(fileName);
+                    var pipelineId = await client.CreatePipelineAsync(project, pipelineFileName, filePath);
+
+                    if (pipelineId < 0)
+                    {
+                        ConsoleHelper.WriteError($"X Failed to create pipeline: {client.LastError}");
+                        return 1;
+                    }
+
+                    ConsoleHelper.WriteLine($"[OK] Pipeline created successfully", ConsoleColor.Green);
+                    Console.WriteLine();
+                    ConsoleHelper.WriteLine($"Pipeline Details:", ConsoleColor.Cyan);
+                    Console.WriteLine($"  Organization: {organization}");
+                    Console.WriteLine($"  Project:      {project}");
+                    Console.WriteLine($"  Pipeline ID:  {pipelineId}");
+                    Console.WriteLine($"  Name:         {pipelineFileName}");
+                    Console.WriteLine($"  YAML File:    {fileName}");
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to create Azure DevOps pipeline: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private void DisplayGitHubMapping(string command)
+
+        {
+            Console.WriteLine();
+            ConsoleHelper.WriteLine("[INFO] GitHub equivalent command:", ConsoleColor.Yellow);
+            ConsoleHelper.WriteLine($"   gh workflow list --repo <owner>/<repo>", ConsoleColor.Yellow);
+            ConsoleHelper.WriteLine($"   gh workflow view <workflow-id> --repo <owner>/<repo>", ConsoleColor.Yellow);
+            Console.WriteLine();
+        }
+
+        private void DisplayAzureDevOpsMapping(string command)
+        {
+            Console.WriteLine();
+            ConsoleHelper.WriteLine("[INFO] Azure DevOps equivalent command:", ConsoleColor.Yellow);
+            ConsoleHelper.WriteLine($"   az pipelines list --project <project>", ConsoleColor.Yellow);
+            ConsoleHelper.WriteLine($"   az pipelines show --id <pipeline-id> --project <project>", ConsoleColor.Yellow);
+            Console.WriteLine();
+        }
+
+        private Task<string?> GetAuthenticationTokenAsync(Platform platform)
+        {
+            // For now, this is a placeholder
+            // In actual implementation, use AuthenticationService
+            return Task.FromResult<string?>(null);
+        }
+
+        private async Task<int> GetStatus(int? buildId, bool verbose)
+        {
+            try
+            {
+                if (verbose) Console.WriteLine("[INFO] Retrieving pipeline build/run status from current Git remote...");
+
+                var platform = _platformDetector.DetectPlatform();
+                var repoInfo = _platformDetector.GetRepositoryInfo();
+
+                if (repoInfo == null || string.IsNullOrEmpty(repoInfo.Owner) || string.IsNullOrEmpty(repoInfo.Repo))
+                {
+                    ConsoleHelper.WriteError("X Unable to determine repository from current Git remote");
+                    if (verbose)
+                    {
+                        Console.WriteLine("Make sure you're in a Git repository with a GitHub or Azure DevOps remote.");
+                    }
+                    return 1;
+                }
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        DisplayGitHubMapping("run");
+                    }
+                    return await GetGitHubRunStatus(repoInfo.Owner, repoInfo.Repo, buildId, verbose);
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        DisplayAzureDevOpsMapping("pipeline show");
+                    }
+                    return await GetAzureDevOpsRunStatus(repoInfo.Organization, repoInfo.Project, repoInfo.Repository, buildId, verbose);
+                }
+
+                ConsoleHelper.WriteError("X Unable to detect platform from Git remote");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Error getting pipeline status: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetGitHubRunStatus(string owner, string repo, int? buildId, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ GitHub Repository: {owner}/{repo}", ConsoleColor.Green);
+
+                if (buildId.HasValue)
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine($"Build ID: {buildId}");
+                    }
+                }
+                else
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine("Showing latest build/run status");
+                    }
+                }
+
+                // Placeholder: In Phase 3.5, we'll add GetRunStatusAsync to GitHubClient
+                ConsoleHelper.WriteLine("[*] Pipeline status would be displayed here", ConsoleColor.Yellow);
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get GitHub run status: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> GetAzureDevOpsRunStatus(string? organization, string? project, string? repository, int? buildId, bool verbose)
+        {
+            try
+            {
+                ConsoleHelper.WriteLine($"✓ Azure DevOps Project: {organization ?? "unknown"}/{project ?? "unknown"}", ConsoleColor.Green);
+                ConsoleHelper.WriteLine($"✓ Repository: {repository ?? "unknown"}", ConsoleColor.Green);
+
+                if (buildId.HasValue)
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine($"Build ID: {buildId}");
+                    }
+                }
+                else
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine("Showing latest build/run status");
+                    }
+                }
+
+                // Placeholder: In Phase 3.5, we'll add GetBuildStatusAsync to AzureDevOpsClient
+                ConsoleHelper.WriteLine("[*] Pipeline status would be displayed here", ConsoleColor.Yellow);
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteError($"X Failed to get Azure DevOps build status: {ex.Message}");
+                return 1;
+            }
+        }
+
+        private async Task<int> UpdatePipeline(bool verbose)
+        {
+            Console.WriteLine("X Pipeline update command not yet implemented");
+            return 1;
+        }
+
+        #endregion
+    }
+}

--- a/Sdo/Commands/PullRequestCommand.cs
+++ b/Sdo/Commands/PullRequestCommand.cs
@@ -282,7 +282,7 @@ namespace Sdo.Commands
                             return 1;
                         }
 
-                        Console.WriteLine("[OK] Pull request created successfully!");
+                        Console.WriteLine("✓ Pull request created successfully!");
                         Console.WriteLine($"URL: {pr.Url}");
                         if (verbose)
                         {
@@ -365,7 +365,7 @@ namespace Sdo.Commands
                         return 1;
                     }
 
-                    Console.WriteLine("[OK] Pull request created successfully!");
+                    Console.WriteLine("✓ Pull request created successfully!");
                     Console.WriteLine($"URL: {pr.Url}");
                     // If a work item ID was provided, attempt to link it to the created PR
                     if (workItem > 0)

--- a/Sdo/Commands/WorkItemCommand.cs
+++ b/Sdo/Commands/WorkItemCommand.cs
@@ -442,11 +442,11 @@ namespace Sdo.Commands
                 {
                     if (!string.IsNullOrEmpty(areaPath))
                     {
-                        ConsoleHelper.WriteLine("✗ --area-path is only supported for Azure DevOps", ConsoleColor.Yellow);
+                        ConsoleHelper.WriteLine("X --area-path is only supported for Azure DevOps", ConsoleColor.Yellow);
                     }
                     if (!string.IsNullOrEmpty(iteration))
                     {
-                        ConsoleHelper.WriteLine("✗ --iteration is only supported for Azure DevOps", ConsoleColor.Yellow);
+                        ConsoleHelper.WriteLine("X --iteration is only supported for Azure DevOps", ConsoleColor.Yellow);
                     }
                     return await ListGitHubIssues(type, state, assignedTo, assignedToMe, top, verbose);
                 }
@@ -1270,7 +1270,7 @@ namespace Sdo.Commands
                         return 0;
                     }
 
-                    ConsoleHelper.WriteLine("✗ Failed to create GitHub issue", ConsoleColor.Red);
+                    ConsoleHelper.WriteLine("X Failed to create GitHub issue", ConsoleColor.Red);
                     return 1;
                 }
                 else if (platform == Platform.AzureDevOps)

--- a/Sdo/Program.cs
+++ b/Sdo/Program.cs
@@ -42,13 +42,12 @@ namespace Sdo
             // Add commands
             rootCommand.Subcommands.Add(new Commands.MapCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.AuthCommand(verboseOption));
+            rootCommand.Subcommands.Add(new Commands.PipelineCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.PullRequestCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.RepositoryCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.WorkItemCommand(verboseOption));
 
-            // TODO: Add subcommands for pull requests, pipelines, and users
-            // Phase 3.4: Pull Request Commands
-            // Phase 3.5: Pipeline Commands
+            // TODO: Add subcommands for users
             // Phase 3.6: User Commands
 
             // For now, just show a placeholder message

--- a/Sdo/Sdo.csproj
+++ b/Sdo/Sdo.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	<PackageReference Include="System.CommandLine" Version="2.0.1" />
+	<PackageReference Include="System.CommandLine" Version="2.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Sdo/Services/AzureDevOpsBuild.cs
+++ b/Sdo/Services/AzureDevOpsBuild.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps build run.
+    /// </summary>
+    public class AzureDevOpsBuild
+    {
+        /// <summary>
+        /// Gets or sets the build ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build number.
+        /// </summary>
+        [JsonPropertyName("buildNumber")]
+        public string? BuildNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build status.
+        /// </summary>
+        public string? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build result.
+        /// </summary>
+        public string? Result { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source branch.
+        /// </summary>
+        [JsonPropertyName("sourceBranch")]
+        public string? SourceBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets queue time.
+        /// </summary>
+        [JsonPropertyName("queueTime")]
+        public DateTime? QueueTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets start time.
+        /// </summary>
+        [JsonPropertyName("startTime")]
+        public DateTime? StartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets finish time.
+        /// </summary>
+        [JsonPropertyName("finishTime")]
+        public DateTime? FinishTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build definition reference.
+        /// </summary>
+        public AzureDevOpsBuildDefinitionReference? Definition { get; set; }
+
+        /// <summary>
+        /// Gets or sets logs resource metadata.
+        /// </summary>
+        public AzureDevOpsResourceReference? Logs { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build URL.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsBuildDefinition.cs
+++ b/Sdo/Services/AzureDevOpsBuildDefinition.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps build definition (pipeline).
+    /// </summary>
+    public class AzureDevOpsBuildDefinition
+    {
+        /// <summary>
+        /// Gets or sets the pipeline ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline folder path.
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline type (e.g., "build").
+        /// </summary>
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the pipeline definition.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revision number.
+        /// </summary>
+        public int Revision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the quality level.
+        /// </summary>
+        public string? Quality { get; set; }
+
+        /// <summary>
+        /// Gets or sets the queue status (e.g., "enabled").
+        /// </summary>
+        [JsonPropertyName("queueStatus")]
+        public string? QueueStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        [JsonPropertyName("createdDate")]
+        public DateTime? CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last modified date.
+        /// </summary>
+        [JsonPropertyName("modifiedDate")]
+        public DateTime? ModifiedDate { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsBuildDefinitionListResponse.cs
+++ b/Sdo/Services/AzureDevOpsBuildDefinitionListResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a list of Azure DevOps build definitions API response.
+    /// </summary>
+    public class AzureDevOpsBuildDefinitionListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of build definitions.
+        /// </summary>
+        public List<AzureDevOpsBuildDefinition>? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the continuation token for pagination.
+        /// </summary>
+        [JsonPropertyName("continuationToken")]
+        public string? ContinuationToken { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsBuildDefinitionReference.cs
+++ b/Sdo/Services/AzureDevOpsBuildDefinitionReference.cs
@@ -1,0 +1,18 @@
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a build definition reference in a build response.
+    /// </summary>
+    public class AzureDevOpsBuildDefinitionReference
+    {
+        /// <summary>
+        /// Gets or sets the definition ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition name.
+        /// </summary>
+        public string? Name { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsBuildListResponse.cs
+++ b/Sdo/Services/AzureDevOpsBuildListResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a list of Azure DevOps builds API response.
+    /// </summary>
+    public class AzureDevOpsBuildListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of builds.
+        /// </summary>
+        public List<AzureDevOpsBuild>? Value { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsClient.cs
+++ b/Sdo/Services/AzureDevOpsClient.cs
@@ -1876,7 +1876,7 @@ namespace Sdo.Services
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    _lastError = $"GitHub API error: {response.StatusCode} {response.ReasonPhrase}";
+                    _lastError = $"Azure DevOps API error: {response.StatusCode} {response.ReasonPhrase}";
                     return null;
                 }
 
@@ -1895,529 +1895,324 @@ namespace Sdo.Services
         }
 
         /// <summary>
+        /// Gets a specific pipeline definition by ID.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="pipelineId">The pipeline definition ID.</param>
+        /// <returns>The pipeline definition, or null if request fails.</returns>
+        public async Task<AzureDevOpsBuildDefinition?> GetPipelineAsync(string project, int pipelineId)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/definitions/{pipelineId}?api-version=7.0";
+                var response = await _httpClient.GetAsync(url);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _lastError = $"Get pipeline failed ({response.StatusCode}): {response.ReasonPhrase}";
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return JsonSerializer.Deserialize<AzureDevOpsBuildDefinition>(content, options);
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Error fetching Azure DevOps pipeline {pipelineId}: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a specific pipeline definition by ID or exact name.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="pipelineIdOrName">Pipeline ID (numeric) or name.</param>
+        /// <returns>The pipeline definition, or null if not found.</returns>
+        public async Task<AzureDevOpsBuildDefinition?> GetPipelineAsync(string project, string pipelineIdOrName)
+        {
+            if (string.IsNullOrWhiteSpace(pipelineIdOrName))
+            {
+                _lastError = "Pipeline ID or name is required.";
+                return null;
+            }
+
+            if (int.TryParse(pipelineIdOrName, out var pipelineId))
+            {
+                return await GetPipelineAsync(project, pipelineId);
+            }
+
+            var pipelines = await ListPipelinesAsync(project);
+            if (pipelines == null || pipelines.Count == 0)
+            {
+                if (string.IsNullOrEmpty(_lastError))
+                {
+                    _lastError = "No pipelines found in this project.";
+                }
+                return null;
+            }
+
+            var match = pipelines.FirstOrDefault(p =>
+                string.Equals(p.Name, pipelineIdOrName, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _lastError = $"Pipeline not found by name: {pipelineIdOrName}";
+            }
+
+            return match;
+        }
+
+        /// <summary>
+        /// Deletes a build definition (pipeline) by numeric ID.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="pipelineId">The build definition ID.</param>
+        /// <returns>True if deletion succeeded (HTTP 204), false otherwise.</returns>
+        public async Task<bool> DeletePipelineAsync(string project, int pipelineId)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{_organization}/{project}/_apis/build/definitions/{pipelineId}?api-version=7.0";
+                var response = await _httpClient.DeleteAsync(url);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    _lastError = $"Delete pipeline failed ({response.StatusCode}): {response.ReasonPhrase}\n{errorContent}";
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception deleting pipeline: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes a build definition (pipeline) by numeric ID or name.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="pipelineIdOrName">Pipeline ID (numeric) or name.</param>
+        /// <returns>True if deletion succeeded, false otherwise.</returns>
+        public async Task<bool> DeletePipelineAsync(string project, string pipelineIdOrName)
+        {
+            if (string.IsNullOrWhiteSpace(pipelineIdOrName))
+            {
+                _lastError = "Pipeline ID or name is required.";
+                return false;
+            }
+
+            if (int.TryParse(pipelineIdOrName, out var pipelineId))
+            {
+                return await DeletePipelineAsync(project, pipelineId);
+            }
+
+            var pipeline = await GetPipelineAsync(project, pipelineIdOrName);
+            if (pipeline == null)
+            {
+                if (string.IsNullOrEmpty(_lastError))
+                {
+                    _lastError = $"Pipeline not found by name: {pipelineIdOrName}";
+                }
+                return false;
+            }
+
+            return await DeletePipelineAsync(project, pipeline.Id);
+        }
+
+        /// <summary>
+        /// Gets a specific build by ID.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="buildId">The build ID.</param>
+        /// <returns>Build details, or null if request fails.</returns>
+        public async Task<AzureDevOpsBuild?> GetBuildAsync(string project, int buildId)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/builds/{buildId}?api-version=7.0";
+                var response = await _httpClient.GetAsync(url);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _lastError = $"Get build failed ({response.StatusCode}): {response.ReasonPhrase}";
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return JsonSerializer.Deserialize<AzureDevOpsBuild>(content, options);
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Error fetching Azure DevOps build {buildId}: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Lists builds in a project, optionally filtered by definition.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="top">Maximum number of builds to return.</param>
+        /// <param name="definitionId">Optional pipeline definition ID filter.</param>
+        /// <returns>List of builds, or null if request fails.</returns>
+        public async Task<List<AzureDevOpsBuild>?> ListBuildsAsync(string project, int top = 10, int? definitionId = null)
+        {
+            try
+            {
+                var safeTop = Math.Max(1, top);
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/builds?api-version=7.0&$top={safeTop}";
+                if (definitionId.HasValue)
+                {
+                    url += $"&definitions={definitionId.Value}";
+                }
+
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _lastError = $"List builds failed ({response.StatusCode}): {response.ReasonPhrase}";
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var buildsResponse = JsonSerializer.Deserialize<AzureDevOpsBuildListResponse>(content, options);
+                return buildsResponse?.Value;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Error listing Azure DevOps builds: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Queues a new build for the specified pipeline definition.
+        /// </summary>
+        /// <param name="project">Project name.</param>
+        /// <param name="definitionId">Pipeline definition ID.</param>
+        /// <param name="branch">Branch to run (e.g. 'main' or 'refs/heads/main').</param>
+        /// <param name="parameters">Optional parameters dictionary (will be serialized to JSON string).</param>
+        /// <returns>New build ID on success, or -1 on failure.</returns>
+        public async Task<int> RunPipelineAsync(string project, int definitionId, string? branch = null, Dictionary<string, string>? parameters = null)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/builds?api-version=7.0";
+
+                var payload = new Dictionary<string, object>
+                {
+                    ["definition"] = new { id = definitionId }
+                };
+
+                if (!string.IsNullOrWhiteSpace(branch))
+                {
+                    var refName = branch.StartsWith("refs/") ? branch : $"refs/heads/{branch}";
+                    payload["sourceBranch"] = refName;
+                }
+
+                if (parameters != null && parameters.Any())
+                {
+                    // Azure DevOps expects parameters as a JSON string
+                    payload["parameters"] = JsonSerializer.Serialize(parameters);
+                }
+
+                var content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync(url, content);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    _lastError = $"Queue build failed ({response.StatusCode}): {response.ReasonPhrase}\n{errorContent}";
+                    return -1;
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var build = JsonSerializer.Deserialize<AzureDevOpsBuild>(responseContent, options);
+
+                return build?.Id ?? -1;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception queuing build: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves and concatenates logs for a given build.
+        /// </summary>
+        /// <param name="project">Project name.</param>
+        /// <param name="buildId">Build/run ID.</param>
+        /// <returns>Concatenated log text, or null if failed.</returns>
+        public async Task<string?> GetBuildLogsAsync(string project, int buildId)
+        {
+            try
+            {
+                var listUrl = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/builds/{buildId}/logs?api-version=7.0";
+                var listResp = await _httpClient.GetAsync(listUrl);
+                if (!listResp.IsSuccessStatusCode)
+                {
+                    var err = await listResp.Content.ReadAsStringAsync();
+                    _lastError = $"Failed to list logs for build {buildId}: {listResp.StatusCode} {listResp.ReasonPhrase}\n{err}";
+                    return null;
+                }
+
+                var listContent = await listResp.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var doc = JsonSerializer.Deserialize<JsonElement>(listContent, options);
+
+                if (!doc.TryGetProperty("value", out var arr) || arr.ValueKind != JsonValueKind.Array)
+                {
+                    _lastError = "No logs found for this build.";
+                    return null;
+                }
+
+                var sb = new System.Text.StringBuilder();
+                foreach (var item in arr.EnumerateArray())
+                {
+                    if (item.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.Number)
+                    {
+                        var id = idProp.GetInt32();
+                        var logUrl = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/builds/{buildId}/logs/{id}?api-version=7.0";
+                        var logResp = await _httpClient.GetAsync(logUrl);
+                        if (logResp.IsSuccessStatusCode)
+                        {
+                            var logText = await logResp.Content.ReadAsStringAsync();
+                            sb.AppendLine($"===== Log {id} =====");
+                            sb.AppendLine(logText);
+                        }
+                    }
+                }
+
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception retrieving build logs: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Disposes the HTTP client.
         /// </summary>
         public void Dispose()
         {
             _httpClient.Dispose();
         }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps project.
-    /// </summary>
-    public class AzureDevOpsProject
-    {
-        /// <summary>
-        /// Gets or sets the project ID.
-        /// </summary>
-        public string? Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project URL.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project state (e.g., 'wellFormed').
-        /// </summary>
-        public string? State { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps project API response.
-    /// </summary>
-    public class AzureDevOpsProjectResponse
-    {
-        /// <summary>
-        /// Gets or sets the project ID.
-        /// </summary>
-        public string? Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project URL.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the project state.
-        /// </summary>
-        public string? State { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a list of Azure DevOps projects API response.
-    /// </summary>
-    public class AzureDevOpsProjectListResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of projects.
-        /// </summary>
-        public List<AzureDevOpsProjectResponse>? Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the continuation token for pagination.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("continuationToken")]
-        public string? ContinuationToken { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps Git repository API response.
-    /// </summary>
-    public class AzureDevOpsRepositoryResponse
-    {
-        /// <summary>
-        /// Gets or sets the repository ID.
-        /// </summary>
-        public string? Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository URL.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository web URL.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("webUrl")]
-        public string? WebUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default branch name.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("defaultBranch")]
-        public string? DefaultBranch { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository size in bytes.
-        /// </summary>
-        public long Size { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a list of Azure DevOps Git repositories API response.
-    /// </summary>
-    public class AzureDevOpsRepositoryListResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of repositories.
-        /// </summary>
-        public List<AzureDevOpsRepositoryResponse>? Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the continuation token for pagination.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("continuationToken")]
-        public string? ContinuationToken { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a work item query result.
-    /// </summary>
-    public class WorkItemQueryResult
-    {
-        /// <summary>
-        /// Gets or sets the list of work items.
-        /// </summary>
-        public List<WorkItemReference>? WorkItems { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a work item reference from a query.
-    /// </summary>
-    public class WorkItemReference
-    {
-        /// <summary>
-        /// Gets or sets the work item ID.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item URL.
-        /// </summary>
-        public string? Url { get; set; }
-    }
-
-    /// <summary>
-    /// Represents the API response for a work item.
-    /// </summary>
-    public class WorkItemResponse
-    {
-        /// <summary>
-        /// Gets or sets the work item ID.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item URL (top-level property from API response).
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item fields.
-        /// </summary>
-        public Dictionary<string, object?>? Fields { get; set; }
-
-        /// <summary>
-        /// Converts to AzureDevOpsWorkItem.
-        /// </summary>
-        public AzureDevOpsWorkItem ToWorkItem()
-        {
-            var item = new AzureDevOpsWorkItem
-            {
-                Id = Id,
-                // Prefer top-level Url property, fall back to Fields if not available
-                Url = !string.IsNullOrEmpty(Url) ? Url :
-                    (Fields?.ContainsKey("System.Url") == true ? Fields["System.Url"]?.ToString() : null),
-            };
-
-            if (Fields != null)
-            {
-                item.Title = Fields.ContainsKey("System.Title") ? Fields["System.Title"]?.ToString() ?? "Unknown" : "Unknown";
-                item.Type = Fields.ContainsKey("System.WorkItemType") ? Fields["System.WorkItemType"]?.ToString() ?? "Unknown" : "Unknown";
-                item.State = Fields.ContainsKey("System.State") ? Fields["System.State"]?.ToString() ?? "New" : "New";
-                item.Description = Fields.ContainsKey("System.Description") ? Fields["System.Description"]?.ToString() : null;
-                
-                if (Fields.ContainsKey("System.CreatedDate") && DateTime.TryParse(Fields["System.CreatedDate"]?.ToString(), out var createdDate))
-                {
-                    item.CreatedDate = createdDate;
-                }
-
-                if (Fields.ContainsKey("System.ChangedDate") && DateTime.TryParse(Fields["System.ChangedDate"]?.ToString(), out var changedDate))
-                {
-                    item.ChangedDate = changedDate;
-                }
-
-                // Extract sprint/iteration path - get the last component after backslash
-                if (Fields.ContainsKey("System.IterationPath"))
-                {
-                    var iterationPath = Fields["System.IterationPath"]?.ToString();
-                    if (!string.IsNullOrEmpty(iterationPath) && iterationPath.Contains("\\"))
-                    {
-                        item.Sprint = iterationPath.Split("\\").LastOrDefault();
-                    }
-                    else if (!string.IsNullOrEmpty(iterationPath))
-                    {
-                        item.Sprint = iterationPath;
-                    }
-                }
-
-                // Extract assigned to user name
-                if (Fields.ContainsKey("System.AssignedTo"))
-                {
-                    var assignedToField = Fields["System.AssignedTo"];
-                    if (assignedToField != null)
-                    {
-                        // Try to handle as JsonElement with displayName property
-                        if (assignedToField is JsonElement jElement)
-                        {
-                            if (jElement.TryGetProperty("displayName", out var displayName))
-                            {
-                                item.AssignedTo = displayName.GetString();
-                            }
-                            else if (jElement.ValueKind == JsonValueKind.String)
-                            {
-                                item.AssignedTo = jElement.GetString();
-                            }
-                        }
-                        else
-                        {
-                            // Fallback: just convert to string
-                            item.AssignedTo = assignedToField.ToString();
-                        }
-                    }
-                }
-
-                // Comments count is typically in comments section, defaulting to 0
-                item.CommentCount = 0;
-            }
-
-            return item;
-        }
-    }
-
-    /// <summary>
-    /// Represents the batch API response for multiple work items.
-    /// </summary>
-    public class BatchWorkItemsResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of work item responses.
-        /// </summary>
-        [JsonPropertyName("value")]
-        public List<WorkItemResponse>? Value { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps work item.
-    /// </summary>
-    public class AzureDevOpsWorkItem
-    {
-        /// <summary>
-        /// Gets or sets the work item ID.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item title.
-        /// </summary>
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item type (PBI, Task, Bug, etc.).
-        /// </summary>
-        public string? Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item state (New, Approved, Committed, Done, etc.).
-        /// </summary>
-        public string? State { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the creation date.
-        /// </summary>
-        public DateTime CreatedDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the last change date.
-        /// </summary>
-        public DateTime ChangedDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of comments.
-        /// </summary>
-        public int CommentCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the work item URL.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the sprint/iteration name.
-        /// </summary>
-        public string? Sprint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the assigned to user name.
-        /// </summary>
-        public string? AssignedTo { get; set; }
-    }
-
-    /// <summary>
-    /// Represents Azure DevOps connection data.
-    /// </summary>
-    public class ConnectionData
-    {
-        /// <summary>
-        /// Gets or sets the authenticated user.
-        /// </summary>
-        public AzureDevOpsUser? AuthenticatedUser { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps user.
-    /// </summary>
-    public class AzureDevOpsUser
-    {
-        /// <summary>
-        /// Gets or sets the user ID.
-        /// </summary>
-        public string? Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the username.
-        /// </summary>
-        public string? UniqueName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the display name.
-        /// </summary>
-        public string? DisplayName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the email address.
-        /// </summary>
-        public string? PreferredEmail { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps pull request API response.
-    /// </summary>
-    public class AzureDevOpsPullRequestResponse
-    {
-        /// <summary>
-        /// Gets or sets the pull request ID.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("pullRequestId")]
-        public int PullRequestId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request title.
-        /// </summary>
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request status.
-        /// </summary>
-        public string? Status { get; set; }
-
-        /// <summary>
-        /// Gets or sets the source ref name (branch).
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("sourceRefName")]
-        public string? SourceRefName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target ref name (branch).
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("targetRefName")]
-        public string? TargetRefName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request URL.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets creation date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("creationDate")]
-        public DateTime CreationDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user who created the pull request.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("createdBy")]
-        public AzureDevOpsUser? CreatedBy { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a list of Azure DevOps pull requests API response.
-    /// </summary>
-    public class AzureDevOpsPullRequestListResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of pull requests.
-        /// </summary>
-        public List<AzureDevOpsPullRequestResponse>? Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the continuation token for pagination.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("continuationToken")]
-        public string? ContinuationToken { get; set; }
-    }
-
-    /// <summary>
-    /// Represents an Azure DevOps build definition (pipeline).
-    /// </summary>
-    public class AzureDevOpsBuildDefinition
-    {
-        /// <summary>
-        /// Gets or sets the pipeline ID.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pipeline name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pipeline folder path.
-        /// </summary>
-        public string? Path { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pipeline type (e.g., "build").
-        /// </summary>
-        public string? Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the URL to the pipeline definition.
-        /// </summary>
-        public string? Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the revision number.
-        /// </summary>
-        public int Revision { get; set; }
-
-        /// <summary>
-        /// Gets or sets the quality level.
-        /// </summary>
-        public string? Quality { get; set; }
-
-        /// <summary>
-        /// Gets or sets the queue status (e.g., "enabled").
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("queueStatus")]
-        public string? QueueStatus { get; set; }
-
-        /// <summary>
-        /// Gets or sets the creation date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("createdDate")]
-        public DateTime? CreatedDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the last modified date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("modifiedDate")]
-        public DateTime? ModifiedDate { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a list of Azure DevOps build definitions API response.
-    /// </summary>
-    public class AzureDevOpsBuildDefinitionListResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of build definitions.
-        /// </summary>
-        public List<AzureDevOpsBuildDefinition>? Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the continuation token for pagination.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("continuationToken")]
-        public string? ContinuationToken { get; set; }
     }
 }

--- a/Sdo/Services/AzureDevOpsClient.cs
+++ b/Sdo/Services/AzureDevOpsClient.cs
@@ -7,6 +7,7 @@
 
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Sdo.Services
@@ -1873,6 +1874,68 @@ namespace Sdo.Services
                 _lastError = $"Exception creating pipeline: {ex.Message}";
                 System.Diagnostics.Debug.WriteLine(_lastError);
                 return -1;
+            }
+        }
+
+        /// <summary>
+        /// Updates an existing pipeline definition to reference the specified YAML filename.
+        /// This performs a GET of the current definition, replaces the process.yamlFilename and process.type,
+        /// then PUTs the modified definition back to Azure DevOps.
+        /// </summary>
+        /// <param name="project">Azure DevOps project name.</param>
+        /// <param name="pipelineId">Numeric pipeline/definition id.</param>
+        /// <param name="yamlFilePath">Repository-relative YAML file path (e.g. "azure-pipelines/ci.yml").</param>
+        /// <returns>True if update succeeded, false otherwise.</returns>
+        public async Task<bool> UpdatePipelineDefinitionYamlAsync(string project, int pipelineId, string yamlFilePath)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(project))
+                {
+                    _lastError = "Project is required to update pipeline definition.";
+                    return false;
+                }
+
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/definitions/{pipelineId}?api-version=7.0";
+
+                // Fetch existing definition
+                var getResp = await _httpClient.GetAsync(url);
+                if (!getResp.IsSuccessStatusCode)
+                {
+                    var err = await getResp.Content.ReadAsStringAsync();
+                    _lastError = $"Failed to fetch pipeline definition ({getResp.StatusCode}): {getResp.ReasonPhrase}\n{err}";
+                    return false;
+                }
+
+                var originalJson = await getResp.Content.ReadAsStringAsync();
+                var node = JsonNode.Parse(originalJson)?.AsObject();
+                if (node == null)
+                {
+                    _lastError = "Failed to parse pipeline definition JSON.";
+                    return false;
+                }
+
+                var processNode = node["process"] as JsonObject ?? new JsonObject();
+                processNode["yamlFilename"] = yamlFilePath;
+                processNode["type"] = 2; // YAML process type
+                node["process"] = processNode;
+
+                var putContent = new StringContent(node.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
+                var putResp = await _httpClient.PutAsync(url, putContent);
+                if (!putResp.IsSuccessStatusCode)
+                {
+                    var putErr = await putResp.Content.ReadAsStringAsync();
+                    _lastError = $"Update pipeline failed ({putResp.StatusCode}): {putResp.ReasonPhrase}\n{putErr}";
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception updating pipeline definition: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return false;
             }
         }
 

--- a/Sdo/Services/AzureDevOpsClient.cs
+++ b/Sdo/Services/AzureDevOpsClient.cs
@@ -45,6 +45,20 @@ namespace Sdo.Services
         }
 
         /// <summary>
+        /// Test-friendly constructor that accepts a preconfigured HttpClient.
+        /// </summary>
+        /// <param name="httpClient">The HttpClient to use for requests (test/mocked).</param>
+        /// <param name="organization">Azure DevOps organization.</param>
+        /// <param name="project">Optional project name.</param>
+        public AzureDevOpsClient(HttpClient httpClient, string organization, string? project = null)
+        {
+            _pat = string.Empty;
+            _organization = organization;
+            _project = project;
+            _httpClient = httpClient ?? throw new System.ArgumentNullException(nameof(httpClient));
+        }
+
+        /// <summary>
         /// Adds a hyperlink relation to a work item pointing to a pull request web URL.
         /// </summary>
         /// <param name="workItemId">Work item numeric ID.</param>
@@ -1892,6 +1906,47 @@ namespace Sdo.Services
                 System.Diagnostics.Debug.WriteLine(_lastError);
                 return null;
             }
+        }
+
+        // ------------------ Neutral model wrappers ------------------
+
+        public async Task<List<PipelineDefinition>?> ListPipelineDefinitionsAsync(string project)
+        {
+            var defs = await ListPipelinesAsync(project);
+            if (defs == null) return null;
+            return defs.Select(d => d.ToPipelineDefinition()).Where(p => p != null).Select(p => p!).ToList();
+        }
+
+        public async Task<PipelineDefinition?> GetPipelineDefinitionAsync(string project, int pipelineId)
+        {
+            var def = await GetPipelineAsync(project, pipelineId);
+            return def?.ToPipelineDefinition();
+        }
+
+        public async Task<PipelineDefinition?> GetPipelineDefinitionAsync(string project, string pipelineIdOrName)
+        {
+            if (string.IsNullOrWhiteSpace(pipelineIdOrName)) return null;
+            if (int.TryParse(pipelineIdOrName, out var id)) return await GetPipelineDefinitionAsync(project, id);
+            var def = await GetPipelineAsync(project, pipelineIdOrName);
+            return def?.ToPipelineDefinition();
+        }
+
+        public async Task<List<PipelineRun>?> ListPipelineRunsAsync(string project, int top = 10, int? definitionId = null)
+        {
+            var builds = await ListBuildsAsync(project, top, definitionId);
+            if (builds == null) return null;
+            return builds.Select(b => b.ToPipelineRun()).Where(p => p != null).Select(p => p!).ToList();
+        }
+
+        public async Task<PipelineRun?> GetPipelineRunAsync(string project, int buildId)
+        {
+            var build = await GetBuildAsync(project, buildId);
+            return build?.ToPipelineRun();
+        }
+
+        public async Task<string?> GetPipelineRunLogsAsync(string project, int buildId)
+        {
+            return await GetBuildLogsAsync(project, buildId);
         }
 
         /// <summary>

--- a/Sdo/Services/AzureDevOpsClient.cs
+++ b/Sdo/Services/AzureDevOpsClient.cs
@@ -671,21 +671,21 @@ namespace Sdo.Services
                 // Test organization access
                 var orgUrl = $"https://dev.azure.com/{_organization}/_apis/projects?api-version=7.0";
                 var response = await _httpClient.GetAsync(orgUrl);
-                result["Organization Access"] = response.IsSuccessStatusCode ? "✓ Allowed" : "✗ Denied";
+                result["Organization Access"] = response.IsSuccessStatusCode ? "✓ Allowed" : "X Denied";
 
                 // Test project access if specified
                 if (!string.IsNullOrEmpty(_project))
                 {
                     var projectUrl = $"https://dev.azure.com/{_organization}/{_project}/_apis/teams?api-version=7.0";
                     var projectResponse = await _httpClient.GetAsync(projectUrl);
-                    result["Project Access"] = projectResponse.IsSuccessStatusCode ? "✓ Allowed" : "✗ Denied";
+                    result["Project Access"] = projectResponse.IsSuccessStatusCode ? "✓ Allowed" : "X Denied";
                 }
 
                 // Test Work Item Query access - this is what fails in workitem list
                 var wiqlUrl = $"https://dev.azure.com/{_organization}/_apis/wit/wiql?api-version=7.0";
                 var wiqlRequest = new StringContent("{\"query\":\"SELECT [System.Id] FROM WorkItems LIMIT 0\"}", System.Text.Encoding.UTF8, "application/json");
                 var wiqlResponse = await _httpClient.PostAsync(wiqlUrl, wiqlRequest);
-                result["Work Item Query Access"] = wiqlResponse.IsSuccessStatusCode ? "✓ Allowed" : "✗ Denied";
+                result["Work Item Query Access"] = wiqlResponse.IsSuccessStatusCode ? "✓ Allowed" : "X Denied";
 
                 return result;
             }
@@ -1793,6 +1793,108 @@ namespace Sdo.Services
         }
 
         /// <summary>
+        /// Creates a new build pipeline from a YAML definition.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <param name="pipelineName">The name for the new pipeline.</param>
+        /// <param name="yamlFilePath">The path to the pipeline YAML file.</param>
+        /// <returns>The created build definition ID, or -1 if creation fails.</returns>
+        public async Task<int> CreatePipelineAsync(string project, string pipelineName, string yamlFilePath)
+        {
+            try
+            {
+                // Read YAML content
+                if (!File.Exists(yamlFilePath))
+                {
+                    _lastError = $"YAML file not found: {yamlFilePath}";
+                    return -1;
+                }
+
+                var yamlContent = await File.ReadAllTextAsync(yamlFilePath);
+
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/definitions?api-version=7.0";
+
+                // Create the build definition request body
+                var createData = new
+                {
+                    name = pipelineName,
+                    type = "build",
+                    process = new
+                    {
+                        yamlFilename = yamlFilePath,
+                        type = 2  // YAML process type
+                    },
+                    repository = new
+                    {
+                        type = "TfsGit"  // Azure DevOps Git repository
+                    }
+                };
+
+                var content = JsonSerializer.Serialize(createData);
+                var request = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
+
+                var response = await _httpClient.PostAsync(url, request);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    _lastError = $"Create pipeline failed ({response.StatusCode}): {response.ReasonPhrase}\n{errorContent}";
+                    return -1;
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var pipelineData = JsonSerializer.Deserialize<AzureDevOpsBuildDefinition>(responseContent, options);
+
+                if (pipelineData == null)
+                {
+                    _lastError = "Failed to parse pipeline response";
+                    return -1;
+                }
+
+                return pipelineData.Id;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception creating pipeline: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Lists build pipelines in a project.
+        /// </summary>
+        /// <param name="project">The project name.</param>
+        /// <returns>List of Azure DevOps build pipelines, or null if request fails.</returns>
+        public async Task<List<AzureDevOpsBuildDefinition>?> ListPipelinesAsync(string project)
+        {
+            try
+            {
+                var url = $"https://dev.azure.com/{_organization}/{System.Uri.EscapeDataString(project)}/_apis/build/definitions?api-version=7.0";
+                var response = await _httpClient.GetAsync(url);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _lastError = $"GitHub API error: {response.StatusCode} {response.ReasonPhrase}";
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var pipelinesResponse = JsonSerializer.Deserialize<AzureDevOpsBuildDefinitionListResponse>(content, options);
+
+                return pipelinesResponse?.Value;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Error fetching Azure DevOps pipelines: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Disposes the HTTP client.
         /// </summary>
         public void Dispose()
@@ -2235,6 +2337,82 @@ namespace Sdo.Services
         /// Gets or sets the list of pull requests.
         /// </summary>
         public List<AzureDevOpsPullRequestResponse>? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the continuation token for pagination.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("continuationToken")]
+        public string? ContinuationToken { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an Azure DevOps build definition (pipeline).
+    /// </summary>
+    public class AzureDevOpsBuildDefinition
+    {
+        /// <summary>
+        /// Gets or sets the pipeline ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline folder path.
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline type (e.g., "build").
+        /// </summary>
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the pipeline definition.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the revision number.
+        /// </summary>
+        public int Revision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the quality level.
+        /// </summary>
+        public string? Quality { get; set; }
+
+        /// <summary>
+        /// Gets or sets the queue status (e.g., "enabled").
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("queueStatus")]
+        public string? QueueStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("createdDate")]
+        public DateTime? CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last modified date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("modifiedDate")]
+        public DateTime? ModifiedDate { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a list of Azure DevOps build definitions API response.
+    /// </summary>
+    public class AzureDevOpsBuildDefinitionListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of build definitions.
+        /// </summary>
+        public List<AzureDevOpsBuildDefinition>? Value { get; set; }
 
         /// <summary>
         /// Gets or sets the continuation token for pagination.

--- a/Sdo/Services/AzureDevOpsCredentials.cs
+++ b/Sdo/Services/AzureDevOpsCredentials.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+//
+// AzureDevOpsCredentials.cs
+//
+// Provides centralized methods for retrieving Azure DevOps credentials (Personal Access Token).
+
+using System.Diagnostics;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Provides methods for retrieving Azure DevOps credentials, such as the Personal Access Token (PAT).
+    /// </summary>
+    public static class AzureDevOpsCredentials
+    {
+        /// <summary>
+        /// Gets the Azure DevOps Personal Access Token.
+        /// </summary>
+        /// <returns>The Azure DevOps PAT.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the token cannot be retrieved from any source.</exception>
+        public static string GetToken()
+        {
+            return GetTokenOrDefault() ?? throw new InvalidOperationException("Azure DevOps Personal Access Token could not be retrieved from environment variable or Azure CLI.");
+        }
+
+        /// <summary>
+        /// Gets the Azure DevOps Personal Access Token, or null if not available.
+        /// </summary>
+        /// <returns>The Azure DevOps PAT, or null if not available.</returns>
+        public static string? GetTokenOrDefault()
+        {
+            // Try environment variable first
+            var token = Environment.GetEnvironmentVariable("AZURE_DEVOPS_PAT");
+            if (!string.IsNullOrEmpty(token))
+            {
+                return token;
+            }
+
+            // Try Azure CLI as fallback
+            try
+            {
+                token = GetTokenFromAzureCli();
+                if (!string.IsNullOrEmpty(token))
+                {
+                    return token;
+                }
+            }
+            catch
+            {
+                // Azure CLI not available or not authenticated
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the Azure DevOps PAT from the Azure CLI.
+        /// </summary>
+        /// <returns>The PAT from Azure CLI, or null if not available.</returns>
+        private static string? GetTokenFromAzureCli()
+        {
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = "account get-access-token --query accessToken -o tsv",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(startInfo);
+                if (process == null)
+                {
+                    return null;
+                }
+
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+
+                if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+                {
+                    return output.Trim();
+                }
+            }
+            catch
+            {
+                // Azure CLI not available or error occurred
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the Azure DevOps organization name.
+        /// </summary>
+        /// <returns>The Azure DevOps organization name.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the organization cannot be determined.</exception>
+        public static string GetOrganization()
+        {
+            // Try environment variable
+            var org = Environment.GetEnvironmentVariable("AZURE_DEVOPS_ORG");
+            if (!string.IsNullOrEmpty(org))
+            {
+                return org;
+            }
+
+            throw new InvalidOperationException("Environment variable 'AZURE_DEVOPS_ORG' is required for Azure DevOps operations.");
+        }
+
+        /// <summary>
+        /// Gets the Azure DevOps organization name, or null if not available.
+        /// </summary>
+        /// <returns>The Azure DevOps organization name, or null if not available.</returns>
+        public static string? GetOrganizationOrDefault()
+        {
+            return Environment.GetEnvironmentVariable("AZURE_DEVOPS_ORG");
+        }
+    }
+}

--- a/Sdo/Services/AzureDevOpsProject.cs
+++ b/Sdo/Services/AzureDevOpsProject.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps project.
+    /// </summary>
+    public class AzureDevOpsProject
+    {
+        /// <summary>
+        /// Gets or sets the project ID.
+        /// </summary>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project URL.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project state (e.g., 'wellFormed').
+        /// </summary>
+        public string? State { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsProjectListResponse.cs
+++ b/Sdo/Services/AzureDevOpsProjectListResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a list of Azure DevOps projects API response.
+    /// </summary>
+    public class AzureDevOpsProjectListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of projects.
+        /// </summary>
+        public List<AzureDevOpsProjectResponse>? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the continuation token for pagination.
+        /// </summary>
+        [JsonPropertyName("continuationToken")]
+        public string? ContinuationToken { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsProjectResponse.cs
+++ b/Sdo/Services/AzureDevOpsProjectResponse.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps project API response.
+    /// </summary>
+    public class AzureDevOpsProjectResponse
+    {
+        /// <summary>
+        /// Gets or sets the project ID.
+        /// </summary>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project URL.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the project state.
+        /// </summary>
+        public string? State { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsPullRequestListResponse.cs
+++ b/Sdo/Services/AzureDevOpsPullRequestListResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a list of Azure DevOps pull requests API response.
+    /// </summary>
+    public class AzureDevOpsPullRequestListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of pull requests.
+        /// </summary>
+        public List<AzureDevOpsPullRequestResponse>? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the continuation token for pagination.
+        /// </summary>
+        [JsonPropertyName("continuationToken")]
+        public string? ContinuationToken { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsPullRequestResponse.cs
+++ b/Sdo/Services/AzureDevOpsPullRequestResponse.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps pull request API response.
+    /// </summary>
+    public class AzureDevOpsPullRequestResponse
+    {
+        /// <summary>
+        /// Gets or sets the pull request ID.
+        /// </summary>
+        [JsonPropertyName("pullRequestId")]
+        public int PullRequestId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request status.
+        /// </summary>
+        public string? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source ref name (branch).
+        /// </summary>
+        [JsonPropertyName("sourceRefName")]
+        public string? SourceRefName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target ref name (branch).
+        /// </summary>
+        [JsonPropertyName("targetRefName")]
+        public string? TargetRefName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request URL.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets creation date.
+        /// </summary>
+        [JsonPropertyName("creationDate")]
+        public DateTime CreationDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user who created the pull request.
+        /// </summary>
+        [JsonPropertyName("createdBy")]
+        public AzureDevOpsUser? CreatedBy { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsRepositoryListResponse.cs
+++ b/Sdo/Services/AzureDevOpsRepositoryListResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a list of Azure DevOps Git repositories API response.
+    /// </summary>
+    public class AzureDevOpsRepositoryListResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of repositories.
+        /// </summary>
+        public List<AzureDevOpsRepositoryResponse>? Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the continuation token for pagination.
+        /// </summary>
+        [JsonPropertyName("continuationToken")]
+        public string? ContinuationToken { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsRepositoryResponse.cs
+++ b/Sdo/Services/AzureDevOpsRepositoryResponse.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps Git repository API response.
+    /// </summary>
+    public class AzureDevOpsRepositoryResponse
+    {
+        /// <summary>
+        /// Gets or sets the repository ID.
+        /// </summary>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository URL.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository web URL.
+        /// </summary>
+        [JsonPropertyName("webUrl")]
+        public string? WebUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default branch name.
+        /// </summary>
+        [JsonPropertyName("defaultBranch")]
+        public string? DefaultBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository size in bytes.
+        /// </summary>
+        public long Size { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsResourceReference.cs
+++ b/Sdo/Services/AzureDevOpsResourceReference.cs
@@ -1,0 +1,13 @@
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a nested resource reference.
+    /// </summary>
+    public class AzureDevOpsResourceReference
+    {
+        /// <summary>
+        /// Gets or sets the resource URL.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsUser.cs
+++ b/Sdo/Services/AzureDevOpsUser.cs
@@ -1,0 +1,28 @@
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps user.
+    /// </summary>
+    public class AzureDevOpsUser
+    {
+        /// <summary>
+        /// Gets or sets the user ID.
+        /// </summary>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        public string? UniqueName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name.
+        /// </summary>
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address.
+        /// </summary>
+        public string? PreferredEmail { get; set; }
+    }
+}

--- a/Sdo/Services/AzureDevOpsWorkItem.cs
+++ b/Sdo/Services/AzureDevOpsWorkItem.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents an Azure DevOps work item.
+    /// </summary>
+    public class AzureDevOpsWorkItem
+    {
+        /// <summary>
+        /// Gets or sets the work item ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item type (PBI, Task, Bug, etc.).
+        /// </summary>
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item state (New, Approved, Committed, Done, etc.).
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        public DateTime CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last change date.
+        /// </summary>
+        public DateTime ChangedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of comments.
+        /// </summary>
+        public int CommentCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item URL.
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sprint/iteration name.
+        /// </summary>
+        public string? Sprint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assigned to user name.
+        /// </summary>
+        public string? AssignedTo { get; set; }
+    }
+}

--- a/Sdo/Services/BatchWorkItemsResponse.cs
+++ b/Sdo/Services/BatchWorkItemsResponse.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents the batch API response for multiple work items.
+    /// </summary>
+    public class BatchWorkItemsResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of work item responses.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public List<WorkItemResponse>? Value { get; set; }
+    }
+}

--- a/Sdo/Services/CheckRun.cs
+++ b/Sdo/Services/CheckRun.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub check run.
+    /// </summary>
+    public class CheckRun
+    {
+        /// <summary>
+        /// Gets or sets the check run name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the check run status.
+        /// </summary>
+        public string? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the check run conclusion.
+        /// </summary>
+        public string? Conclusion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start time.
+        /// </summary>
+        [JsonPropertyName("started_at")]
+        public DateTime? StartedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the completion time.
+        /// </summary>
+        [JsonPropertyName("completed_at")]
+        public DateTime? CompletedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the details URL.
+        /// </summary>
+        [JsonPropertyName("details_url")]
+        public string? DetailsUrl { get; set; }
+    }
+}

--- a/Sdo/Services/CheckRunsResponse.cs
+++ b/Sdo/Services/CheckRunsResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents the check runs response from GitHub API.
+    /// </summary>
+    public class CheckRunsResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of check runs.
+        /// </summary>
+        [JsonPropertyName("check_runs")]
+        public List<CheckRun>? CheckRuns { get; set; }
+    }
+}

--- a/Sdo/Services/ConnectionData.cs
+++ b/Sdo/Services/ConnectionData.cs
@@ -1,0 +1,13 @@
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents Azure DevOps connection data.
+    /// </summary>
+    public class ConnectionData
+    {
+        /// <summary>
+        /// Gets or sets the authenticated user.
+        /// </summary>
+        public AzureDevOpsUser? AuthenticatedUser { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubClient.cs
+++ b/Sdo/Services/GitHubClient.cs
@@ -6,10 +6,12 @@
 // GitHub API client for authentication verification and basic operations.
 // Reuses GitHubRelease authentication logic for token retrieval.
 
-using Nbuild;
+
 using Nbuild.Helpers;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.IO.Compression;
+using System.Text;
 
 namespace Sdo.Services
 {
@@ -87,13 +89,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Gets a specific GitHub issue.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="issueNumber">Issue number.</param>
-        /// <returns>The GitHub issue, or null if not found.</returns>
         public async Task<GitHubIssue?> GetIssueAsync(string owner, string repo, int issueNumber)
         {
             try
@@ -118,15 +113,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Lists GitHub issues in a repository.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="perPage">Number of issues to return (clamped to 1-100). Defaults to 50.</param>
-        /// <param name="state">Issue state filter: 'open', 'closed', or 'all'. Defaults to 'open'.</param>
-        /// <param name="top">Maximum total issues to retrieve. 0 means no limit.</param>
-        /// <returns>List of GitHub issues (excluding pull requests).</returns>
         public async Task<List<GitHubIssue>?> ListIssuesAsync(string owner, string repo, int perPage = 50, string state = "open", int top = 0)
         {
             try
@@ -134,10 +120,8 @@ namespace Sdo.Services
                 var allIssues = new List<GitHubIssue>();
                 int page = 1;
 
-                // Clamp perPage to GitHub API limits (1-100)
                 int pageSize = perPage < 1 ? 1 : (perPage > 100 ? 100 : perPage);
 
-                // Fetch pages until we have enough items or reach the end
                 while (true)
                 {
                     var url = $"https://api.github.com/repos/{owner}/{repo}/issues?per_page={pageSize}&page={page}&state={state}";
@@ -146,7 +130,6 @@ namespace Sdo.Services
                     if (!response.IsSuccessStatusCode)
                     {
                         ConsoleHelper.WriteLine($"GitHub API error: {response.StatusCode} {response.ReasonPhrase}", ConsoleColor.Red);
-                        // Return what we have so far if first page succeeded
                         return allIssues.Count > 0 ? allIssues : null;
                     }
 
@@ -156,24 +139,19 @@ namespace Sdo.Services
 
                     if (issues == null || issues.Count == 0)
                     {
-                        // No more results
                         break;
                     }
 
-                    // Filter out pull requests (they have the pull_request field)
                     var filteredIssues = issues.Where(i => i.PullRequest == null).ToList();
 
                     allIssues.AddRange(filteredIssues);
 
-                    // Check if we've reached the requested limit
                     if (top > 0 && allIssues.Count >= top)
                     {
-                        // Trim to exact count
                         allIssues = allIssues.Take(top).ToList();
                         break;
                     }
 
-                    // If we got fewer items than pageSize, we've reached the end
                     if (issues.Count < pageSize)
                     {
                         break;
@@ -191,17 +169,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Updates a GitHub issue.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="issueNumber">Issue number.</param>
-        /// <param name="title">New issue title (optional).</param>
-        /// <param name="state">New issue state: 'open' or 'closed' (optional).</param>
-        /// <param name="body">New issue body/description (optional).</param>
-        /// <param name="assignee">New assignee login name (optional).</param>
-        /// <returns>The updated GitHub issue, or null if update failed.</returns>
         public async Task<GitHubIssue?> UpdateIssueAsync(string owner, string repo, int issueNumber,
             string? title = null, string? state = null, string? body = null, string? assignee = null)
         {
@@ -209,7 +176,6 @@ namespace Sdo.Services
             {
                 var url = $"https://api.github.com/repos/{owner}/{repo}/issues/{issueNumber}";
 
-                // Build request body with only provided fields
                 var updateData = new Dictionary<string, object?>();
                 if (!string.IsNullOrEmpty(title))
                     updateData["title"] = title;
@@ -243,14 +209,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Adds a comment to a GitHub issue.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="issueNumber">Issue number.</param>
-        /// <param name="body">Comment text.</param>
-        /// <returns>True if comment was added successfully, false otherwise.</returns>
         public async Task<bool> AddCommentAsync(string owner, string repo, int issueNumber, string body)
         {
             try
@@ -278,17 +236,7 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Creates a new GitHub issue.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="title">Issue title (required).</param>
-        /// <param name="body">Issue body/description (optional).</param>
-        /// <param name="labels">Labels to assign to the issue (optional).</param>
-        /// <param name="assignee">Assignee login name (optional).</param>
-        /// <returns>The created GitHub issue, or null if creation failed.</returns>
-        public async Task<GitHubIssue?> CreateIssueAsync(string owner, string repo, string title, 
+        public async Task<GitHubIssue?> CreateIssueAsync(string owner, string repo, string title,
             string? body = null, string[]? labels = null, string? assignee = null)
         {
             try
@@ -332,23 +280,13 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Lists repositories for the authenticated user or a specific organization.
-        /// </summary>
-        /// <param name="organization">Optional organization name. If null, lists authenticated user's repositories.</param>
-        /// <param name="visibility">Filter by visibility: 'all', 'public', or 'private'. Default: 'all'.</param>
-        /// <param name="perPage">Number of results per page (1-100). Default: 30.</param>
-        /// <param name="top">Maximum number of results to return. Default: 0 (all).</param>
-        /// <returns>List of repositories, or null if operation failed.</returns>
         public async Task<List<Models.Repository>?> ListRepositoriesAsync(string? organization = null,
             string visibility = "all", int perPage = 30, int top = 0)
         {
             try
             {
-                // Clamp perPage to valid GitHub API range (1-100)
                 perPage = Math.Max(1, Math.Min(100, perPage));
 
-                // Determine the URL based on whether we're querying user or org repos
                 string baseUrl = string.IsNullOrEmpty(organization)
                     ? "https://api.github.com/user/repos"
                     : $"https://api.github.com/orgs/{organization}/repos";
@@ -378,11 +316,9 @@ namespace Sdo.Services
 
                     if (repos == null || repos.Count == 0)
                     {
-                        // No more results
                         break;
                     }
 
-                    // Convert to Repository model
                     allRepos.AddRange(repos.Select(r => new Models.Repository
                     {
                         Name = r.Name,
@@ -394,14 +330,12 @@ namespace Sdo.Services
                         PlatformId = r.Id.ToString()
                     }));
 
-                    // Check if we've reached the requested limit
                     if (top > 0 && allRepos.Count >= top)
                     {
                         allRepos = allRepos.Take(top).ToList();
                         break;
                     }
 
-                    // If we got fewer items than pageSize, we've reached the end
                     if (repos.Count < perPage)
                     {
                         break;
@@ -419,12 +353,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Gets details for a specific repository.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <returns>Repository details, or null if not found.</returns>
         public async Task<Models.Repository?> GetRepositoryAsync(string owner, string repo)
         {
             try
@@ -465,13 +393,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Creates a new repository for the authenticated user.
-        /// </summary>
-        /// <param name="name">Repository name (required).</param>
-        /// <param name="description">Repository description (optional).</param>
-        /// <param name="isPrivate">Whether the repository should be private.</param>
-        /// <returns>Created repository details, or null if creation failed.</returns>
         public async Task<Models.Repository?> CreateRepositoryAsync(string name, string? description = null, bool isPrivate = false)
         {
             try
@@ -524,12 +445,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Deletes a repository.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <returns>True if deletion was successful, false otherwise.</returns>
         public async Task<bool> DeleteRepositoryAsync(string owner, string repo)
         {
             try
@@ -552,14 +467,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Updates repository settings.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="description">New repository description (optional).</param>
-        /// <param name="isPrivate">New privacy setting (optional).</param>
-        /// <returns>Updated repository details, or null if update failed.</returns>
         public async Task<Models.Repository?> UpdateRepositoryAsync(string owner, string repo,
             string? description = null, bool? isPrivate = null)
         {
@@ -615,17 +522,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Creates a new pull request.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="title">Pull request title (required).</param>
-        /// <param name="body">Pull request description (optional).</param>
-        /// <param name="head">Branch name or commit SHA to merge from (required).</param>
-        /// <param name="baseRef">Branch name to merge into (required).</param>
-        /// <param name="draft">Whether the PR should be a draft (optional).</param>
-        /// <returns>Created pull request details, or null if creation failed.</returns>
         public async Task<Models.PullRequest?> CreatePullRequestAsync(string owner, string repo, string title,
             string head, string baseRef, string? body = null, bool draft = false)
         {
@@ -687,13 +583,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Gets details for a specific pull request.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="prNumber">Pull request number.</param>
-        /// <returns>Pull request details, or null if not found.</returns>
         public async Task<Models.PullRequest?> GetPullRequestAsync(string owner, string repo, int prNumber)
         {
             try
@@ -741,21 +630,11 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Lists pull requests for a repository.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="state">Filter by state: 'open', 'closed', or 'all'. Default: 'open'.</param>
-        /// <param name="perPage">Number of results per page (1-100). Default: 30.</param>
-        /// <param name="top">Maximum number of results to return. Default: 0 (all).</param>
-        /// <returns>List of pull requests, or null if operation failed.</returns>
         public async Task<List<Models.PullRequest>?> ListPullRequestsAsync(string owner, string repo,
             string state = "open", int perPage = 30, int top = 0)
         {
             try
             {
-                // Clamp perPage to GitHub API limits (1-100)
                 perPage = Math.Max(1, Math.Min(100, perPage));
 
                 var allPRs = new List<Models.PullRequest>();
@@ -778,11 +657,9 @@ namespace Sdo.Services
 
                     if (prs == null || prs.Count == 0)
                     {
-                        // No more results
                         break;
                     }
 
-                    // Convert to PullRequest model
                     allPRs.AddRange(prs.Select(pr => new Models.PullRequest
                     {
                         Number = pr.Number,
@@ -801,14 +678,12 @@ namespace Sdo.Services
                         IsMerged = pr.Merged
                     }));
 
-                    // Check if we've reached the requested limit
                     if (top > 0 && allPRs.Count >= top)
                     {
                         allPRs = allPRs.Take(top).ToList();
                         break;
                     }
 
-                    // If we got fewer items than perPage, we've reached the end
                     if (prs.Count < perPage)
                     {
                         break;
@@ -826,13 +701,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Approves a pull request by creating a review.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="prNumber">Pull request number.</param>
-        /// <returns>True if approval was successful, false otherwise.</returns>
         public async Task<bool> ApprovePullRequestAsync(string owner, string repo, int prNumber)
         {
             try
@@ -864,14 +732,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Merges a pull request.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="prNumber">Pull request number.</param>
-        /// <param name="mergeMethod">Merge method: 'merge', 'squash', or 'rebase'. Default: 'merge'.</param>
-        /// <returns>True if merge was successful, false otherwise.</returns>
         public async Task<bool> MergePullRequestAsync(string owner, string repo, int prNumber,
             string mergeMethod = "merge")
         {
@@ -904,16 +764,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Updates a pull request.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="prNumber">Pull request number.</param>
-        /// <param name="title">New pull request title (optional).</param>
-        /// <param name="body">New pull request body (optional).</param>
-        /// <param name="state">New pull request state: 'open' or 'closed' (optional).</param>
-        /// <returns>Updated pull request details, or null if update failed.</returns>
         public async Task<Models.PullRequest?> UpdatePullRequestAsync(string owner, string repo, int prNumber,
             string? title = null, string? body = null, string? state = null)
         {
@@ -974,13 +824,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Gets check runs for a specific commit/PR head.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <param name="headSha">The commit SHA of the PR head.</param>
-        /// <returns>List of check runs with name, status, and URL, or null if operation failed.</returns>
         public async Task<List<(string Name, string Status, string Duration, string Url)>?> GetCheckRunsAsync(
             string owner, string repo, string headSha)
         {
@@ -1007,7 +850,6 @@ namespace Sdo.Services
                 var checks = new List<(string, string, string, string)>();
                 foreach (var check in result.CheckRuns)
                 {
-                    // Calculate duration
                     string duration = "pending";
                     if (check.CompletedAt.HasValue && check.StartedAt.HasValue)
                     {
@@ -1026,14 +868,12 @@ namespace Sdo.Services
                         }
                     }
 
-                    // Map conclusion to status
                     var status = check.Conclusion ?? "pending";
                     if (check.Status == "in_progress")
                     {
                         status = "running";
                     }
 
-                    // Get the details URL - GitHub checks have a details_url
                     var checkUrl = check.DetailsUrl ?? $"https://github.com/{owner}/{repo}/pull";
 
                     checks.Add((check.Name ?? "Unknown", status, duration, checkUrl));
@@ -1048,12 +888,6 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Lists workflows in a GitHub repository.
-        /// </summary>
-        /// <param name="owner">Repository owner.</param>
-        /// <param name="repo">Repository name.</param>
-        /// <returns>List of GitHub workflows, or null if request fails.</returns>
         public async Task<List<GitHubWorkflow>?> ListWorkflowsAsync(string owner, string repo)
         {
             try
@@ -1080,24 +914,123 @@ namespace Sdo.Services
             }
         }
 
-        /// <summary>
-        /// Creates a new GitHub Actions workflow from a YAML definition file.
-        /// Note: GitHub API does not provide direct workflow creation endpoint.
-        /// Returns true if file would be created (validation only); actual creation requires git commit/push.
-        /// </summary>
-        /// <param name="owner">The repository owner/organization.</param>
-        /// <param name="repo">The repository name.</param>
-        /// <param name="workflowName">The name for the workflow file (without path).</param>
-        /// <param name="yamlFilePath">The path to the workflow YAML file to be created.</param>
-        /// <returns>True if validation passed and workflow can be created via git commit, false otherwise.</returns>
+        public async Task<List<GitHubWorkflowRun>?> ListWorkflowRunsAsync(string owner, string repo, long? workflowId = null, int perPage = 10)
+        {
+            try
+            {
+                var safePerPage = Math.Max(1, Math.Min(100, perPage));
+                var url = workflowId.HasValue
+                    ? $"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflowId.Value}/runs?per_page={safePerPage}"
+                    : $"https://api.github.com/repos/{owner}/{repo}/actions/runs?per_page={safePerPage}";
+
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    System.Diagnostics.Debug.WriteLine($"GitHub API error listing workflow runs: {response.StatusCode} {response.ReasonPhrase}");
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var runsResponse = JsonSerializer.Deserialize<GitHubWorkflowRunsResponse>(content, options);
+                return runsResponse?.WorkflowRuns;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error listing workflow runs: {ex.Message}");
+                return null;
+            }
+        }
+
+        public async Task<GitHubWorkflowRun?> GetWorkflowRunAsync(string owner, string repo, long runId)
+        {
+            try
+            {
+                var url = $"https://api.github.com/repos/{owner}/{repo}/actions/runs/{runId}";
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    System.Diagnostics.Debug.WriteLine($"GitHub API error getting workflow run {runId}: {response.StatusCode} {response.ReasonPhrase}");
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return JsonSerializer.Deserialize<GitHubWorkflowRun>(content, options);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error getting workflow run {runId}: {ex.Message}");
+                return null;
+            }
+        }
+
+        public async Task<GitHubWorkflow?> GetWorkflowAsync(string owner, string repo, long workflowId)
+        {
+            try
+            {
+                var url = $"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflowId}";
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    System.Diagnostics.Debug.WriteLine($"GitHub API error getting workflow {workflowId}: {response.StatusCode} {response.ReasonPhrase}");
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                return JsonSerializer.Deserialize<GitHubWorkflow>(content, options);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error getting workflow {workflowId}: {ex.Message}");
+                return null;
+            }
+        }
+
+        public async Task<bool> TriggerWorkflowAsync(string owner, string repo, long workflowId, string @ref, Dictionary<string, string>? inputs = null)
+        {
+            try
+            {
+                var url = $"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflowId}/dispatches";
+                var body = new Dictionary<string, object>
+                {
+                    ["ref"] = @ref
+                };
+                if (inputs != null && inputs.Any())
+                {
+                    body["inputs"] = inputs;
+                }
+
+                var content = new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync(url, content);
+                return response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error triggering workflow {workflowId}: {ex.Message}");
+                return false;
+            }
+        }
+
+        public async Task<string?> GetWorkflowLogsAsync(string owner, string repo, long runId)
+        {
+            try
+            {
+                var url = $"https://api.github.com/repos/{owner}/{repo}/actions/runs/{runId}/logs";
+                return await DownloadAndExtractLogsAsync(url);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error getting workflow logs for run {runId}: {ex.Message}");
+                return null;
+            }
+        }
+
         public async Task<bool> CreateWorkflowAsync(string owner, string repo, string workflowName, string yamlFilePath)
         {
             try
             {
-                // GitHub doesn't have a direct API to create workflows
-                // Workflows are created by committing YAML files to .github/workflows/
-                // This method validates that such a file can be created
-
                 if (!File.Exists(yamlFilePath))
                 {
                     System.Diagnostics.Debug.WriteLine($"YAML file not found: {yamlFilePath}");
@@ -1112,7 +1045,6 @@ namespace Sdo.Services
                     return false;
                 }
 
-                // Validate the repository exists and is accessible
                 var repoCheck = await GetRepositoryAsync(owner, repo);
                 if (repoCheck == null)
                 {
@@ -1120,8 +1052,6 @@ namespace Sdo.Services
                     return false;
                 }
 
-                // Validation passed - workflow can be created
-                // The actual creation will happen when the file is committed and pushed to .github/workflows/
                 return true;
             }
             catch (Exception ex)
@@ -1130,6 +1060,7 @@ namespace Sdo.Services
                 return false;
             }
         }
+        // For brevity the file keeps the original client methods.
 
         /// <summary>
         /// Disposes the HTTP client.
@@ -1138,404 +1069,41 @@ namespace Sdo.Services
         {
             _httpClient.Dispose();
         }
-    }
-
-    /// <summary>
-    /// Represents a GitHub repository API response.
-    /// </summary>
-    public class GitHubRepositoryResponse
-    {
-        /// <summary>
-        /// Gets or sets the repository ID.
-        /// </summary>
-        public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the repository name.
+        /// Downloads and extracts the log content from a GitHub Actions logs_url (zip file).
         /// </summary>
-        public string? Name { get; set; }
+        /// <param name="logsUrl">The logs_url from the workflow run.</param>
+        /// <returns>Concatenated log text, or null if failed.</returns>
+        public async Task<string?> DownloadAndExtractLogsAsync(string logsUrl)
+        {
+            try
+            {
+                var response = await _httpClient.GetAsync(logsUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    System.Diagnostics.Debug.WriteLine($"GitHub API error downloading logs: {response.StatusCode}");
+                    return null;
+                }
 
-        /// <summary>
-        /// Gets or sets the repository description.
-        /// </summary>
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the repository is private.
-        /// </summary>
-        public bool Private { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default branch name.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("default_branch")]
-        public string? DefaultBranch { get; set; }
-
-        /// <summary>
-        /// Gets or sets the HTML URL of the repository.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
-        public string? HtmlUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository owner.
-        /// </summary>
-        public GitHubUser? Owner { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of stargazers.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("stargazers_count")]
-        public int StargazersCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of watchers.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("watchers_count")]
-        public int WatchersCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of forks.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("forks_count")]
-        public int ForksCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the repository topics/tags.
-        /// </summary>
-        public List<string>? Topics { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub user.
-    /// </summary>
-    public class GitHubUser
-    {
-        /// <summary>
-        /// Gets or sets the user ID.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the username.
-        /// </summary>
-        public string? Login { get; set; }
-
-        /// <summary>
-        /// Gets or sets the display name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the email address.
-        /// </summary>
-        public string? Email { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub issue.
-    /// </summary>
-    public class GitHubIssue
-    {
-        /// <summary>
-        /// Gets or sets the issue ID (using long to support large GitHub issue IDs).
-        /// </summary>
-        public long Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the issue number.
-        /// </summary>
-        public int Number { get; set; }
-
-        /// <summary>
-        /// Gets or sets the issue title.
-        /// </summary>
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// Gets or sets the issue body/description.
-        /// </summary>
-        public string? Body { get; set; }
-
-        /// <summary>
-        /// Gets or sets the issue state (open, closed).
-        /// </summary>
-        public string? State { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of comments.
-        /// </summary>
-        public int Comments { get; set; }
-
-        /// <summary>
-        /// Gets or sets the creation date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
-        public DateTime CreatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the last update date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
-        public DateTime UpdatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the HTML URL of the issue.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
-        public string? HtmlUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the labels assigned to the issue.
-        /// </summary>
-        public List<GitHubLabel>? Labels { get; set; }
-
-        /// <summary>
-        /// Gets or sets the assignee of the issue.
-        /// </summary>
-        public GitHubUser? Assignee { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request object (null for issues, non-null for PRs).
-        /// Used to distinguish between issues and pull requests.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("pull_request")]
-        public object? PullRequest { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub issue label.
-    /// </summary>
-    public class GitHubLabel
-    {
-        /// <summary>
-        /// Gets or sets the label name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the label color.
-        /// </summary>
-        public string? Color { get; set; }
-
-        /// <summary>
-        /// Gets or sets the label description.
-        /// </summary>
-        public string? Description { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub pull request API response.
-    /// </summary>
-    public class GitHubPullRequest
-    {
-        /// <summary>
-        /// Gets or sets the pull request ID.
-        /// </summary>
-        public long Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request number.
-        /// </summary>
-        public int Number { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request title.
-        /// </summary>
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request body/description.
-        /// </summary>
-        public string? Body { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request state (open, closed).
-        /// </summary>
-        public string? State { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the pull request is a draft.
-        /// </summary>
-        public bool Draft { get; set; }
-
-        /// <summary>
-        /// Gets or sets the creation date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
-        public DateTime CreatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the last update date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
-        public DateTime UpdatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the merge date (if merged).
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("merged_at")]
-        public DateTime? MergedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the pull request is merged.
-        /// </summary>
-        public bool Merged { get; set; }
-
-        /// <summary>
-        /// Gets or sets the HTML URL of the pull request.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
-        public string? HtmlUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pull request author/user.
-        /// </summary>
-        public GitHubUser? User { get; set; }
-
-        /// <summary>
-        /// Gets or sets the source branch information.
-        /// </summary>
-        public GitHubRef? Head { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target branch information.
-        /// </summary>
-        public GitHubRef? Base { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub ref (branch) reference.
-    /// </summary>
-    public class GitHubRef
-    {
-        /// <summary>
-        /// Gets or sets the ref name (branch name).
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("ref")]
-        public string? Ref { get; set; }
-
-        /// <summary>
-        /// Gets or sets the commit SHA.
-        /// </summary>
-        public string? Sha { get; set; }
-    }
-
-    /// <summary>
-    /// Represents the check runs response from GitHub API.
-    /// </summary>
-    public class CheckRunsResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of check runs.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("check_runs")]
-        public List<CheckRun>? CheckRuns { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub check run.
-    /// </summary>
-    public class CheckRun
-    {
-        /// <summary>
-        /// Gets or sets the check run name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the check run status.
-        /// </summary>
-        public string? Status { get; set; }
-
-        /// <summary>
-        /// Gets or sets the check run conclusion.
-        /// </summary>
-        public string? Conclusion { get; set; }
-
-        /// <summary>
-        /// Gets or sets the start time.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("started_at")]
-        public DateTime? StartedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the completion time.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("completed_at")]
-        public DateTime? CompletedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the details URL.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("details_url")]
-        public string? DetailsUrl { get; set; }
-    }
-
-    /// <summary>
-    /// Represents the workflows list response from GitHub API.
-    /// </summary>
-    public class WorkflowsResponse
-    {
-        /// <summary>
-        /// Gets or sets the list of workflows.
-        /// </summary>
-        public List<GitHubWorkflow>? Workflows { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a GitHub Actions workflow.
-    /// </summary>
-    public class GitHubWorkflow
-    {
-        /// <summary>
-        /// Gets or sets the workflow ID.
-        /// </summary>
-        public long Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the workflow node ID.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("node_id")]
-        public string? NodeId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the workflow name.
-        /// </summary>
-        public string? Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the workflow path.
-        /// </summary>
-        public string? Path { get; set; }
-
-        /// <summary>
-        /// Gets or sets the workflow state.
-        /// </summary>
-        public string? State { get; set; }
-
-        /// <summary>
-        /// Gets or sets the creation date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
-        public DateTime? CreatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the last update date.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
-        public DateTime? UpdatedAt { get; set; }
-
-        /// <summary>
-        /// Gets or sets the HTML URL.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
-        public string? HtmlUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the badge URL.
-        /// </summary>
-        [System.Text.Json.Serialization.JsonPropertyName("badge_url")]
-        public string? BadgeUrl { get; set; }
+                using var zipStream = await response.Content.ReadAsStreamAsync();
+                using var archive = new ZipArchive(zipStream);
+                var allText = new StringBuilder();
+                foreach (var entry in archive.Entries)
+                {
+                    if (entry.Length == 0) continue;
+                    using var entryStream = entry.Open();
+                    using var reader = new StreamReader(entryStream);
+                    allText.AppendLine($"===== {entry.FullName} =====");
+                    allText.AppendLine(await reader.ReadToEndAsync());
+                }
+                return allText.ToString();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error extracting GitHub logs: {ex.Message}");
+                return null;
+            }
+        }
     }
 }

--- a/Sdo/Services/GitHubClient.cs
+++ b/Sdo/Services/GitHubClient.cs
@@ -7,6 +7,7 @@
 // Reuses GitHubRelease authentication logic for token retrieval.
 
 
+using System;
 using Nbuild.Helpers;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -22,6 +23,7 @@ namespace Sdo.Services
     {
         private readonly HttpClient _httpClient;
         private readonly string? _overrideToken;
+        private readonly bool _disposeHttpClient;
 
         /// <summary>
         /// Initializes a new instance of the GitHubClient class.
@@ -31,6 +33,7 @@ namespace Sdo.Services
         {
             _overrideToken = token;
             _httpClient = new HttpClient();
+            _disposeHttpClient = true;
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("sdo-cli", "1.0"));
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
 
@@ -40,6 +43,19 @@ namespace Sdo.Services
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", authToken);
             }
+        }
+
+        /// <summary>
+        /// Constructs a GitHubClient using an externally provided HttpClient.
+        /// This is useful for unit testing where a mocked HttpMessageHandler can be supplied.
+        /// </summary>
+        /// <param name="httpClient">Pre-configured HttpClient instance.</param>
+        /// <param name="token">Optional token override.</param>
+        public GitHubClient(HttpClient httpClient, string? token = null)
+        {
+            _overrideToken = token;
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _disposeHttpClient = false; // caller owns the provided HttpClient
         }
 
         /// <summary>
@@ -1063,11 +1079,14 @@ namespace Sdo.Services
         // For brevity the file keeps the original client methods.
 
         /// <summary>
-        /// Disposes the HTTP client.
+        /// Disposes the HTTP client if this instance owns it.
         /// </summary>
         public void Dispose()
         {
-            _httpClient.Dispose();
+            if (_disposeHttpClient)
+            {
+                _httpClient.Dispose();
+            }
         }
 
         /// <summary>

--- a/Sdo/Services/GitHubClient.cs
+++ b/Sdo/Services/GitHubClient.cs
@@ -1043,6 +1043,44 @@ namespace Sdo.Services
             }
         }
 
+        // ------------------ Neutral model wrappers ------------------
+
+        public async Task<List<PipelineDefinition>?> ListPipelineDefinitionsAsync(string owner, string repo)
+        {
+            var workflows = await ListWorkflowsAsync(owner, repo);
+            if (workflows == null) return null;
+            return workflows.Select(w => w.ToPipelineDefinition()).Where(p => p != null).Select(p => p!).ToList();
+        }
+
+        public async Task<List<PipelineRun>?> ListPipelineRunsAsync(string owner, string repo, long? workflowId = null, int perPage = 10)
+        {
+            var runs = await ListWorkflowRunsAsync(owner, repo, workflowId, perPage);
+            if (runs == null) return null;
+            return runs.Select(r => r.ToPipelineRun()).Where(p => p != null).Select(p => p!).ToList();
+        }
+
+        public async Task<PipelineDefinition?> GetPipelineDefinitionAsync(string owner, string repo, long workflowId)
+        {
+            var wf = await GetWorkflowAsync(owner, repo, workflowId);
+            return wf?.ToPipelineDefinition();
+        }
+
+        public async Task<PipelineRun?> GetPipelineRunAsync(string owner, string repo, long runId)
+        {
+            var run = await GetWorkflowRunAsync(owner, repo, runId);
+            return run?.ToPipelineRun();
+        }
+
+        public async Task<bool> TriggerPipelineAsync(string owner, string repo, long workflowId, string @ref, Dictionary<string, string>? inputs = null)
+        {
+            return await TriggerWorkflowAsync(owner, repo, workflowId, @ref, inputs);
+        }
+
+        public async Task<string?> GetPipelineRunLogsAsync(string owner, string repo, long runId)
+        {
+            return await GetWorkflowLogsAsync(owner, repo, runId);
+        }
+
         public async Task<bool> CreateWorkflowAsync(string owner, string repo, string workflowName, string yamlFilePath)
         {
             try

--- a/Sdo/Services/GitHubClient.cs
+++ b/Sdo/Services/GitHubClient.cs
@@ -1049,6 +1049,89 @@ namespace Sdo.Services
         }
 
         /// <summary>
+        /// Lists workflows in a GitHub repository.
+        /// </summary>
+        /// <param name="owner">Repository owner.</param>
+        /// <param name="repo">Repository name.</param>
+        /// <returns>List of GitHub workflows, or null if request fails.</returns>
+        public async Task<List<GitHubWorkflow>?> ListWorkflowsAsync(string owner, string repo)
+        {
+            try
+            {
+                var url = $"https://api.github.com/repos/{owner}/{repo}/actions/workflows";
+                var response = await _httpClient.GetAsync(url);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    System.Diagnostics.Debug.WriteLine($"GitHub API error: {response.StatusCode} {response.ReasonPhrase}");
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var workflowsResponse = JsonSerializer.Deserialize<WorkflowsResponse>(content, options);
+
+                return workflowsResponse?.Workflows;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error fetching GitHub workflows: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new GitHub Actions workflow from a YAML definition file.
+        /// Note: GitHub API does not provide direct workflow creation endpoint.
+        /// Returns true if file would be created (validation only); actual creation requires git commit/push.
+        /// </summary>
+        /// <param name="owner">The repository owner/organization.</param>
+        /// <param name="repo">The repository name.</param>
+        /// <param name="workflowName">The name for the workflow file (without path).</param>
+        /// <param name="yamlFilePath">The path to the workflow YAML file to be created.</param>
+        /// <returns>True if validation passed and workflow can be created via git commit, false otherwise.</returns>
+        public async Task<bool> CreateWorkflowAsync(string owner, string repo, string workflowName, string yamlFilePath)
+        {
+            try
+            {
+                // GitHub doesn't have a direct API to create workflows
+                // Workflows are created by committing YAML files to .github/workflows/
+                // This method validates that such a file can be created
+
+                if (!File.Exists(yamlFilePath))
+                {
+                    System.Diagnostics.Debug.WriteLine($"YAML file not found: {yamlFilePath}");
+                    return false;
+                }
+
+                var yamlContent = await File.ReadAllTextAsync(yamlFilePath);
+
+                if (string.IsNullOrWhiteSpace(yamlContent))
+                {
+                    System.Diagnostics.Debug.WriteLine("YAML file is empty");
+                    return false;
+                }
+
+                // Validate the repository exists and is accessible
+                var repoCheck = await GetRepositoryAsync(owner, repo);
+                if (repoCheck == null)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Repository {owner}/{repo} not found or not accessible");
+                    return false;
+                }
+
+                // Validation passed - workflow can be created
+                // The actual creation will happen when the file is committed and pushed to .github/workflows/
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error validating workflow creation: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Disposes the HTTP client.
         /// </summary>
         public void Dispose()
@@ -1387,5 +1470,72 @@ namespace Sdo.Services
         /// </summary>
         [System.Text.Json.Serialization.JsonPropertyName("details_url")]
         public string? DetailsUrl { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the workflows list response from GitHub API.
+    /// </summary>
+    public class WorkflowsResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of workflows.
+        /// </summary>
+        public List<GitHubWorkflow>? Workflows { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a GitHub Actions workflow.
+    /// </summary>
+    public class GitHubWorkflow
+    {
+        /// <summary>
+        /// Gets or sets the workflow ID.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow node ID.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("node_id")]
+        public string? NodeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow path.
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow state.
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last update date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the badge URL.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("badge_url")]
+        public string? BadgeUrl { get; set; }
     }
 }

--- a/Sdo/Services/GitHubIssue.cs
+++ b/Sdo/Services/GitHubIssue.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub issue.
+    /// </summary>
+    public class GitHubIssue
+    {
+        /// <summary>
+        /// Gets or sets the issue ID (using long to support large GitHub issue IDs).
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issue number.
+        /// </summary>
+        public int Number { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issue title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issue body/description.
+        /// </summary>
+        public string? Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issue state (open, closed).
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of comments.
+        /// </summary>
+        public int Comments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last update date.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the issue.
+        /// </summary>
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the labels assigned to the issue.
+        /// </summary>
+        public List<GitHubLabel>? Labels { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assignee of the issue.
+        /// </summary>
+        public GitHubUser? Assignee { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request object (null for issues, non-null for PRs).
+        /// Used to distinguish between issues and pull requests.
+        /// </summary>
+        [JsonPropertyName("pull_request")]
+        public object? PullRequest { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubLabel.cs
+++ b/Sdo/Services/GitHubLabel.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub issue label.
+    /// </summary>
+    public class GitHubLabel
+    {
+        /// <summary>
+        /// Gets or sets the label name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the label color.
+        /// </summary>
+        public string? Color { get; set; }
+
+        /// <summary>
+        /// Gets or sets the label description.
+        /// </summary>
+        public string? Description { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubPullRequest.cs
+++ b/Sdo/Services/GitHubPullRequest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub pull request API response.
+    /// </summary>
+    public class GitHubPullRequest
+    {
+        /// <summary>
+        /// Gets or sets the pull request ID.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request number.
+        /// </summary>
+        public int Number { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request body/description.
+        /// </summary>
+        public string? Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request state (open, closed).
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the pull request is a draft.
+        /// </summary>
+        public bool Draft { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last update date.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the merge date (if merged).
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("merged_at")]
+        public DateTime? MergedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the pull request is merged.
+        /// </summary>
+        public bool Merged { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the pull request.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pull request author/user.
+        /// </summary>
+        public GitHubUser? User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source branch information.
+        /// </summary>
+        public GitHubRef? Head { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target branch information.
+        /// </summary>
+        public GitHubRef? Base { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubRef.cs
+++ b/Sdo/Services/GitHubRef.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub ref (branch) reference.
+    /// </summary>
+    public class GitHubRef
+    {
+        /// <summary>
+        /// Gets or sets the ref name (branch name).
+        /// </summary>
+        [JsonPropertyName("ref")]
+        public string? Ref { get; set; }
+
+        /// <summary>
+        /// Gets or sets the commit SHA.
+        /// </summary>
+        public string? Sha { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubRepositoryResponse.cs
+++ b/Sdo/Services/GitHubRepositoryResponse.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub repository API response.
+    /// </summary>
+    public class GitHubRepositoryResponse
+    {
+        /// <summary>
+        /// Gets or sets the repository ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the repository is private.
+        /// </summary>
+        public bool Private { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default branch name.
+        /// </summary>
+        [JsonPropertyName("default_branch")]
+        public string? DefaultBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the repository.
+        /// </summary>
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository owner.
+        /// </summary>
+        public GitHubUser? Owner { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of stargazers.
+        /// </summary>
+        [JsonPropertyName("stargazers_count")]
+        public int StargazersCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of watchers.
+        /// </summary>
+        [JsonPropertyName("watchers_count")]
+        public int WatchersCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of forks.
+        /// </summary>
+        [JsonPropertyName("forks_count")]
+        public int ForksCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository topics/tags.
+        /// </summary>
+        public List<string>? Topics { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubUser.cs
+++ b/Sdo/Services/GitHubUser.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub user.
+    /// </summary>
+    public class GitHubUser
+    {
+        /// <summary>
+        /// Gets or sets the user ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        public string? Login { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address.
+        /// </summary>
+        public string? Email { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubWorkflow.cs
+++ b/Sdo/Services/GitHubWorkflow.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+//
+// GitHubWorkflow.cs
+//
+// GitHub API client for authentication verification and basic operations.
+// Reuses GitHubRelease authentication logic for token retrieval.
+
+
+using Nbuild;
+using Nbuild.Helpers;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.IO.Compression;
+using System.Text;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub Actions workflow.
+    /// </summary>
+    public class GitHubWorkflow
+    {
+        /// <summary>
+        /// Gets or sets the workflow ID.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow node ID.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("node_id")]
+        public string? NodeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the workflow file in the repository (e.g. .github/workflows/ci.yml).
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow state (e.g. "active" or "disabled").
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the workflow was created.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the workflow was last updated.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the workflow.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("badge_url")]
+        public string? BadgeUrl { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubWorkflowRun.cs
+++ b/Sdo/Services/GitHubWorkflowRun.cs
@@ -1,0 +1,81 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a GitHub Actions workflow run.
+    /// </summary>
+    public class GitHubWorkflowRun
+    {
+        /// <summary>
+        /// Gets or sets the workflow run ID.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow run number.
+        /// </summary>
+        [JsonPropertyName("run_number")]
+        public int RunNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the workflow run name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the branch for the run.
+        /// </summary>
+        [JsonPropertyName("head_branch")]
+        public string? HeadBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the run event.
+        /// </summary>
+        public string? Event { get; set; }
+
+        /// <summary>
+        /// Gets or sets the run status.
+        /// </summary>
+        public string? Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the run conclusion.
+        /// </summary>
+        public string? Conclusion { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the run started.
+        /// </summary>
+        [JsonPropertyName("run_started_at")]
+        public DateTime? RunStartedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the run was created.
+        /// </summary>
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the run was last updated.
+        /// </summary>
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL for the run details page.
+        /// </summary>
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the API URL for logs.
+        /// </summary>
+        [JsonPropertyName("logs_url")]
+        public string? LogsUrl { get; set; }
+    }
+}

--- a/Sdo/Services/GitHubWorkflowRunsResponse.cs
+++ b/Sdo/Services/GitHubWorkflowRunsResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents the workflow runs response from GitHub API.
+    /// </summary>
+    public class GitHubWorkflowRunsResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of workflow runs.
+        /// </summary>
+        [JsonPropertyName("workflow_runs")]
+        public List<GitHubWorkflowRun>? WorkflowRuns { get; set; }
+    }
+}

--- a/Sdo/Services/IPipeline.cs
+++ b/Sdo/Services/IPipeline.cs
@@ -1,0 +1,22 @@
+// IPipeline.cs
+// Lightweight interface for pipeline-like models.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Lightweight interface representing common pipeline properties.
+    /// </summary>
+    public interface IPipeline
+    {
+        /// <summary>Platform-specific identifier (stringified).</summary>
+        string? PlatformId { get; set; }
+
+        /// <summary>Name of the pipeline or run.</summary>
+        string? Name { get; set; }
+
+        /// <summary>URL or HTML link to the pipeline or run.</summary>
+        string? Url { get; set; }
+    }
+}

--- a/Sdo/Services/Pipeline.cs
+++ b/Sdo/Services/Pipeline.cs
@@ -1,0 +1,27 @@
+// Pipeline.cs
+// Shared base class for pipeline-like models.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Base pipeline model capturing common properties between definitions and runs.
+    /// </summary>
+    public abstract class Pipeline : IPipeline
+    {
+        /// <summary>Platform-specific identifier (stringified).</summary>
+        public string? PlatformId { get; set; }
+
+        /// <summary>Name of the pipeline or run.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>URL or HTML link to the pipeline or run.</summary>
+        public string? Url { get; set; }
+
+        public override string ToString()
+        {
+            return Name ?? PlatformId ?? base.ToString()!;
+        }
+    }
+}

--- a/Sdo/Services/PipelineDefinition.cs
+++ b/Sdo/Services/PipelineDefinition.cs
@@ -8,22 +8,13 @@ namespace Sdo.Services
     /// <summary>
     /// Neutral representation of a pipeline/workflow definition.
     /// </summary>
-    public class PipelineDefinition : IPipeline
+    public class PipelineDefinition : Pipeline
     {
-        /// <summary>Platform-specific identifier (stringified).</summary>
-        public string? PlatformId { get; set; }
-
-        /// <summary>Name of the pipeline/workflow.</summary>
-        public string? Name { get; set; }
-
         /// <summary>Path to the definition file (if applicable).</summary>
         public string? Path { get; set; }
 
         /// <summary>Type or category (e.g., "build").</summary>
         public string? Type { get; set; }
-
-        /// <summary>URL or HTML link to the definition.</summary>
-        public string? Url { get; set; }
 
         /// <summary>State (e.g., active/disabled).</summary>
         public string? State { get; set; }

--- a/Sdo/Services/PipelineDefinition.cs
+++ b/Sdo/Services/PipelineDefinition.cs
@@ -1,0 +1,37 @@
+// PipelineDefinition.cs
+// Neutral representation of a pipeline/workflow definition.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Neutral representation of a pipeline/workflow definition.
+    /// </summary>
+    public class PipelineDefinition : IPipeline
+    {
+        /// <summary>Platform-specific identifier (stringified).</summary>
+        public string? PlatformId { get; set; }
+
+        /// <summary>Name of the pipeline/workflow.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Path to the definition file (if applicable).</summary>
+        public string? Path { get; set; }
+
+        /// <summary>Type or category (e.g., "build").</summary>
+        public string? Type { get; set; }
+
+        /// <summary>URL or HTML link to the definition.</summary>
+        public string? Url { get; set; }
+
+        /// <summary>State (e.g., active/disabled).</summary>
+        public string? State { get; set; }
+
+        /// <summary>Creation timestamp.</summary>
+        public DateTime? CreatedAt { get; set; }
+
+        /// <summary>Last update timestamp.</summary>
+        public DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/Sdo/Services/PipelineExtensions.cs
+++ b/Sdo/Services/PipelineExtensions.cs
@@ -1,0 +1,73 @@
+// PipelineExtensions.cs
+// Conversion helpers to map platform-specific DTOs to neutral pipeline models.
+
+using System;
+
+namespace Sdo.Services
+{
+    public static class PipelineExtensions
+    {
+        public static PipelineDefinition? ToPipelineDefinition(this GitHubWorkflow? wf)
+        {
+            if (wf == null) return null;
+            return new PipelineDefinition
+            {
+                PlatformId = wf.Id.ToString(),
+                Name = wf.Name,
+                Path = wf.Path,
+                Url = wf.HtmlUrl,
+                State = wf.State,
+                CreatedAt = wf.CreatedAt,
+                UpdatedAt = wf.UpdatedAt
+            };
+        }
+
+        public static PipelineDefinition? ToPipelineDefinition(this AzureDevOpsBuildDefinition? def)
+        {
+            if (def == null) return null;
+            return new PipelineDefinition
+            {
+                PlatformId = def.Id.ToString(),
+                Name = def.Name,
+                Path = def.Path,
+                Type = def.Type,
+                Url = def.Url,
+                State = def.QueueStatus,
+                CreatedAt = def.CreatedDate,
+                UpdatedAt = def.ModifiedDate
+            };
+        }
+
+        public static PipelineRun? ToPipelineRun(this GitHubWorkflowRun? run)
+        {
+            if (run == null) return null;
+            return new PipelineRun
+            {
+                PlatformId = run.Id.ToString(),
+                Name = run.Name,
+                Branch = run.HeadBranch,
+                Status = run.Status,
+                Result = run.Conclusion,
+                StartedAt = run.RunStartedAt,
+                FinishedAt = run.UpdatedAt,
+                Url = run.HtmlUrl
+            };
+        }
+
+        public static PipelineRun? ToPipelineRun(this AzureDevOpsBuild? build)
+        {
+            if (build == null) return null;
+            return new PipelineRun
+            {
+                PlatformId = build.Id.ToString(),
+                Name = build.BuildNumber,
+                Branch = build.SourceBranch,
+                Status = build.Status,
+                Result = build.Result,
+                StartedAt = build.StartTime,
+                FinishedAt = build.FinishTime,
+                Url = build.Url
+            };
+        }
+    }
+}

--- a/Sdo/Services/PipelineRun.cs
+++ b/Sdo/Services/PipelineRun.cs
@@ -8,14 +8,8 @@ namespace Sdo.Services
     /// <summary>
     /// Neutral representation of a pipeline/workflow run.
     /// </summary>
-    public class PipelineRun : IPipeline
+    public class PipelineRun : Pipeline
     {
-        /// <summary>Platform-specific identifier (stringified).</summary>
-        public string? PlatformId { get; set; }
-
-        /// <summary>Friendly name or build number.</summary>
-        public string? Name { get; set; }
-
         /// <summary>Branch or ref the run executed on.</summary>
         public string? Branch { get; set; }
 
@@ -30,8 +24,5 @@ namespace Sdo.Services
 
         /// <summary>When the run finished (or last updated).</summary>
         public DateTime? FinishedAt { get; set; }
-
-        /// <summary>URL to the run details.</summary>
-        public string? Url { get; set; }
     }
 }

--- a/Sdo/Services/PipelineRun.cs
+++ b/Sdo/Services/PipelineRun.cs
@@ -1,0 +1,37 @@
+// PipelineRun.cs
+// Neutral representation of a pipeline/workflow run.
+
+using System;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Neutral representation of a pipeline/workflow run.
+    /// </summary>
+    public class PipelineRun : IPipeline
+    {
+        /// <summary>Platform-specific identifier (stringified).</summary>
+        public string? PlatformId { get; set; }
+
+        /// <summary>Friendly name or build number.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Branch or ref the run executed on.</summary>
+        public string? Branch { get; set; }
+
+        /// <summary>Run status (e.g., in_progress, completed).</summary>
+        public string? Status { get; set; }
+
+        /// <summary>Result/conclusion (e.g., success, failed).</summary>
+        public string? Result { get; set; }
+
+        /// <summary>When the run started.</summary>
+        public DateTime? StartedAt { get; set; }
+
+        /// <summary>When the run finished (or last updated).</summary>
+        public DateTime? FinishedAt { get; set; }
+
+        /// <summary>URL to the run details.</summary>
+        public string? Url { get; set; }
+    }
+}

--- a/Sdo/Services/PlatformService.cs
+++ b/Sdo/Services/PlatformService.cs
@@ -106,7 +106,10 @@ namespace Sdo.Services
                     return new RepositoryInfo
                     {
                         Owner = _organization,
-                        Repo = _repository ?? _project
+                        Repo = _repository ?? _project,
+                        Organization = _organization,
+                        Project = _project,
+                        Repository = _repository ?? _project
                     };
                 }
 

--- a/Sdo/Services/RepositoryInfo.cs
+++ b/Sdo/Services/RepositoryInfo.cs
@@ -9,18 +9,33 @@
 namespace Sdo.Services
 {
     /// <summary>
-    /// Represents GitHub repository information.
+    /// Represents GitHub or Azure DevOps repository information.
     /// </summary>
     public class RepositoryInfo
     {
         /// <summary>
-        /// Gets or sets the repository owner.
+        /// Gets or sets the repository owner (GitHub) or organization (Azure DevOps).
         /// </summary>
         public string? Owner { get; set; }
 
         /// <summary>
-        /// Gets or sets the repository name.
+        /// Gets or sets the repository name (GitHub) or repository name (Azure DevOps).
         /// </summary>
         public string? Repo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure DevOps organization name.
+        /// </summary>
+        public string? Organization { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure DevOps project name.
+        /// </summary>
+        public string? Project { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure DevOps repository name.
+        /// </summary>
+        public string? Repository { get; set; }
     }
 }

--- a/Sdo/Services/WorkItemQueryResult.cs
+++ b/Sdo/Services/WorkItemQueryResult.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a work item query result.
+    /// </summary>
+    public class WorkItemQueryResult
+    {
+        /// <summary>
+        /// Gets or sets the list of work items.
+        /// </summary>
+        public List<WorkItemReference>? WorkItems { get; set; }
+    }
+}

--- a/Sdo/Services/WorkItemReference.cs
+++ b/Sdo/Services/WorkItemReference.cs
@@ -1,0 +1,18 @@
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents a work item reference from a query.
+    /// </summary>
+    public class WorkItemReference
+    {
+        /// <summary>
+        /// Gets or sets the work item ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item URL.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}

--- a/Sdo/Services/WorkItemResponse.cs
+++ b/Sdo/Services/WorkItemResponse.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents the API response for a work item.
+    /// </summary>
+    public class WorkItemResponse
+    {
+        /// <summary>
+        /// Gets or sets the work item ID.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item URL (top-level property from API response).
+        /// </summary>
+        public string? Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the work item fields.
+        /// </summary>
+        public Dictionary<string, object?>? Fields { get; set; }
+
+        /// <summary>
+        /// Converts to AzureDevOpsWorkItem.
+        /// </summary>
+        public AzureDevOpsWorkItem ToWorkItem()
+        {
+            var item = new AzureDevOpsWorkItem
+            {
+                Id = Id,
+                // Prefer top-level Url property, fall back to Fields if not available
+                Url = !string.IsNullOrEmpty(Url) ? Url :
+                    (Fields?.ContainsKey("System.Url") == true ? Fields["System.Url"]?.ToString() : null),
+            };
+
+            if (Fields != null)
+            {
+                item.Title = Fields.ContainsKey("System.Title") ? Fields["System.Title"]?.ToString() ?? "Unknown" : "Unknown";
+                item.Type = Fields.ContainsKey("System.WorkItemType") ? Fields["System.WorkItemType"]?.ToString() ?? "Unknown" : "Unknown";
+                item.State = Fields.ContainsKey("System.State") ? Fields["System.State"]?.ToString() ?? "New" : "New";
+                item.Description = Fields.ContainsKey("System.Description") ? Fields["System.Description"]?.ToString() : null;
+                
+                if (Fields.ContainsKey("System.CreatedDate") && DateTime.TryParse(Fields["System.CreatedDate"]?.ToString(), out var createdDate))
+                {
+                    item.CreatedDate = createdDate;
+                }
+
+                if (Fields.ContainsKey("System.ChangedDate") && DateTime.TryParse(Fields["System.ChangedDate"]?.ToString(), out var changedDate))
+                {
+                    item.ChangedDate = changedDate;
+                }
+
+                // Extract sprint/iteration path - get the last component after backslash
+                if (Fields.ContainsKey("System.IterationPath"))
+                {
+                    var iterationPath = Fields["System.IterationPath"]?.ToString();
+                    if (!string.IsNullOrEmpty(iterationPath) && iterationPath.Contains("\\"))
+                    {
+                        item.Sprint = iterationPath.Split("\\").LastOrDefault();
+                    }
+                    else if (!string.IsNullOrEmpty(iterationPath))
+                    {
+                        item.Sprint = iterationPath;
+                    }
+                }
+
+                // Extract assigned to user name
+                if (Fields.ContainsKey("System.AssignedTo"))
+                {
+                    var assignedToField = Fields["System.AssignedTo"];
+                    if (assignedToField != null)
+                    {
+                        // Try to handle as JsonElement with displayName property
+                        if (assignedToField is JsonElement jElement)
+                        {
+                            if (jElement.TryGetProperty("displayName", out var displayName))
+                            {
+                                item.AssignedTo = displayName.GetString();
+                            }
+                            else if (jElement.ValueKind == JsonValueKind.String)
+                            {
+                                item.AssignedTo = jElement.GetString();
+                            }
+                        }
+                        else
+                        {
+                            // Fallback: just convert to string
+                            item.AssignedTo = assignedToField.ToString();
+                        }
+                    }
+                }
+
+                // Comments count is typically in comments section, defaulting to 0
+                item.CommentCount = 0;
+            }
+
+            return item;
+        }
+    }
+}

--- a/Sdo/Services/WorkflowsResponse.cs
+++ b/Sdo/Services/WorkflowsResponse.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Sdo.Services
+{
+    /// <summary>
+    /// Represents the workflows list response from GitHub API.
+    /// </summary>
+    public class WorkflowsResponse
+    {
+        /// <summary>
+        /// Gets or sets the list of workflows.
+        /// </summary>
+        public List<GitHubWorkflow>? Workflows { get; set; }
+    }
+}

--- a/SdoTests/AzureDevOpsClientTests.cs
+++ b/SdoTests/AzureDevOpsClientTests.cs
@@ -93,4 +93,44 @@ public class AzureDevOpsClientTests
         // Assert
         Assert.Null(user);
     }
+
+    [Fact]
+    public async Task AdHoc_GetPipelineAsync_WithConfiguredEnvironment_ReturnsPipeline()
+    {
+        // Arrange (ad hoc integration style)
+        var token = Environment.GetEnvironmentVariable("AZURE_DEVOPS_PAT");
+        var organization = Environment.GetEnvironmentVariable("AZURE_DEVOPS_ORG");
+        var project = Environment.GetEnvironmentVariable("AZURE_DEVOPS_PROJECT");
+
+        if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project))
+        {
+            return; // Skip if environment not configured
+        }
+
+        using var client = new AzureDevOpsClient(token, organization, project);
+
+        // Pick the first pipeline from live data, then fetch it by ID
+        var pipelines = await client.ListPipelinesAsync(project);
+        if (pipelines == null || pipelines.Count == 0)
+        {
+            return; // Skip if project has no pipelines
+        }
+
+        var first = pipelines[0];
+
+        // Act
+        var byId = await client.GetPipelineAsync(project, first.Id);
+        var byName = string.IsNullOrWhiteSpace(first.Name)
+            ? null
+            : await client.GetPipelineAsync(project, first.Name);
+
+        // Assert
+        Assert.NotNull(byId);
+        Assert.Equal(first.Id, byId!.Id);
+        if (!string.IsNullOrWhiteSpace(first.Name))
+        {
+            Assert.NotNull(byName);
+            Assert.Equal(first.Id, byName!.Id);
+        }
+    }
 }

--- a/SdoTests/PipelineCommandTests.cs
+++ b/SdoTests/PipelineCommandTests.cs
@@ -1,0 +1,287 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+//
+// PipelineCommandTests.cs
+//
+// Unit tests for PipelineCommand - pipeline/workflow management operations.
+
+using System.CommandLine;
+using Xunit;
+using Sdo.Commands;
+
+namespace SdoTests;
+
+/// <summary>
+/// Unit tests for PipelineCommand covering all subcommands and options.
+/// </summary>
+public class PipelineCommandTests
+{
+    private readonly Option<bool> _verboseOption;
+
+    public PipelineCommandTests()
+    {
+        _verboseOption = new Option<bool>("--verbose");
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Constructor_CreatesCommandWithCorrectName()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        Assert.Equal("pipeline", command.Name);
+    }
+
+    [Fact]
+    public void Constructor_CreatesCommandWithCorrectDescription()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        Assert.NotNull(command.Description);
+        Assert.Contains("Pipeline", command.Description);
+    }
+
+    [Fact]
+    public void Constructor_Has9Subcommands()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        Assert.Equal(9, command.Subcommands.Count);
+    }
+
+    [Fact]
+    public void Constructor_RegistersSubcommandsInAlphabeticalOrder()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var subcommandNames = command.Subcommands.Select(s => s.Name).ToList();
+        var expected = new[] { "create", "delete", "lastbuild", "list", "logs", "run", "show", "status", "update" };
+        Assert.Equal(expected, subcommandNames);
+    }
+
+    #endregion
+
+    #region Individual Subcommand Tests
+
+    [Fact]
+    public void Constructor_AddsCreateSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var createCmd = Assert.Single(command.Subcommands, s => s.Name == "create");
+        Assert.NotNull(createCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsDeleteSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var deleteCmd = Assert.Single(command.Subcommands, s => s.Name == "delete");
+        Assert.NotNull(deleteCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsLastbuildSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var lastbuildCmd = Assert.Single(command.Subcommands, s => s.Name == "lastbuild");
+        Assert.NotNull(lastbuildCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsListSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var listCmd = Assert.Single(command.Subcommands, s => s.Name == "list");
+        Assert.NotNull(listCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsLogsSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var logsCmd = Assert.Single(command.Subcommands, s => s.Name == "logs");
+        Assert.NotNull(logsCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsRunSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var runCmd = Assert.Single(command.Subcommands, s => s.Name == "run");
+        Assert.NotNull(runCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsShowSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var showCmd = Assert.Single(command.Subcommands, s => s.Name == "show");
+        Assert.NotNull(showCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsStatusSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var statusCmd = Assert.Single(command.Subcommands, s => s.Name == "status");
+        Assert.NotNull(statusCmd);
+    }
+
+    [Fact]
+    public void Constructor_AddsUpdateSubcommand()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var updateCmd = Assert.Single(command.Subcommands, s => s.Name == "update");
+        Assert.NotNull(updateCmd);
+    }
+
+    #endregion
+
+    #region Subcommand Options Tests
+
+    [Fact]
+    public void CreateSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var createCmd = command.Subcommands.First(s => s.Name == "create");
+        Assert.NotEmpty(createCmd.Options);
+    }
+
+    [Fact]
+    public void CreateSubcommand_HasFileArgument()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var createCmd = command.Subcommands.First(s => s.Name == "create");
+        Assert.NotEmpty(createCmd.Arguments);
+    }
+
+    [Fact]
+    public void CreateCommand_CanBeCalledWithFilePath()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var createCmd = command.Subcommands.First(s => s.Name == "create");
+        var fileArg = createCmd.Arguments.FirstOrDefault(a => a.Name.Contains("file"));
+        Assert.NotNull(fileArg);
+    }
+
+    [Fact]
+    public void DeleteSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var deleteCmd = command.Subcommands.First(s => s.Name == "delete");
+        // Should have force option and verbose option
+        Assert.True(deleteCmd.Options.Count >= 2);
+    }
+
+    [Fact]
+    public void DeleteSubcommand_HasPipelineIdArgument()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var deleteCmd = command.Subcommands.First(s => s.Name == "delete");
+        Assert.NotEmpty(deleteCmd.Arguments);
+    }
+
+    [Fact]
+    public void DeleteCommand_HasForceOption()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var deleteCmd = command.Subcommands.First(s => s.Name == "delete");
+        // Verify force option exists (can be checked by name containing "force")
+        var hasForceOption = deleteCmd.Options.Any(o => o.Name.Contains("force"));
+        Assert.True(hasForceOption);
+    }
+
+    [Fact]
+    public void LastbuildSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var lastbuildCmd = command.Subcommands.First(s => s.Name == "lastbuild");
+        Assert.NotEmpty(lastbuildCmd.Options);
+    }
+
+    [Fact]
+    public void LastbuildSubcommand_HasPipelineNameArgument()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var lastbuildCmd = command.Subcommands.First(s => s.Name == "lastbuild");
+        Assert.NotEmpty(lastbuildCmd.Arguments);
+    }
+
+    [Fact]
+    public void ListSubcommand_HasMultipleOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var listCmd = command.Subcommands.First(s => s.Name == "list");
+        // List should have: verbose, repo, and all options
+        Assert.True(listCmd.Options.Count >= 3);
+    }
+
+    [Fact]
+    public void ListCommand_NoRequiredArguments()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var listCmd = command.Subcommands.First(s => s.Name == "list");
+        // List command should have no required arguments
+        var requiredArgs = listCmd.Arguments.Where(a => a.Arity.MinimumNumberOfValues > 0).ToList();
+        Assert.Empty(requiredArgs);
+    }
+
+    [Fact]
+    public void ListCommand_CanBeCalledWithoutOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var listCmd = command.Subcommands.First(s => s.Name == "list");
+        Assert.NotNull(listCmd);
+        Assert.NotEmpty(listCmd.Options);
+    }
+
+    [Fact]
+    public void LogsSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var logsCmd = command.Subcommands.First(s => s.Name == "logs");
+        Assert.NotEmpty(logsCmd.Options);
+    }
+
+    [Fact]
+    public void RunSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var runCmd = command.Subcommands.First(s => s.Name == "run");
+        // Should have branch option and verbose option
+        Assert.True(runCmd.Options.Count >= 2);
+    }
+
+    [Fact]
+    public void ShowSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var showCmd = command.Subcommands.First(s => s.Name == "show");
+        Assert.NotEmpty(showCmd.Options);
+    }
+
+    [Fact]
+    public void ShowCommand_NoArguments()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var showCmd = command.Subcommands.First(s => s.Name == "show");
+        // Show command should have no required arguments
+        var requiredArgs = showCmd.Arguments.Where(a => a.Arity.MinimumNumberOfValues > 0).ToList();
+        Assert.Empty(requiredArgs);
+    }
+
+    [Fact]
+    public void StatusSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var statusCmd = command.Subcommands.First(s => s.Name == "status");
+        Assert.NotEmpty(statusCmd.Options);
+    }
+
+    [Fact]
+    public void UpdateSubcommand_HasOptions()
+    {
+        var command = new PipelineCommand(_verboseOption);
+        var updateCmd = command.Subcommands.First(s => s.Name == "update");
+        Assert.NotEmpty(updateCmd.Options);
+    }
+
+    #endregion
+}

--- a/SdoTests/Services/AzureDevOpsClientPipelineTests.cs
+++ b/SdoTests/Services/AzureDevOpsClientPipelineTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+using System.IO;
+using Xunit;
+using Sdo.Services;
+
+namespace SdoTests.Services
+{
+    public class AzureDevOpsClientPipelineTests
+    {
+        private class TestHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+            public TestHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            {
+                _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return _responder(request, cancellationToken);
+            }
+        }
+
+        [Fact]
+        public async Task ListPipelineDefinitionsAsync_ReturnsPipelineDefinitions()
+        {
+            var organization = "org";
+            var project = "proj";
+
+                        var definitionsJson = @"{
+    ""value"": [
+        {
+            ""id"": 123,
+            ""name"": ""CI"",
+            ""path"": "".github/workflows/ci.yml"",
+            ""type"": ""build"",
+            ""url"": ""https://dev.azure.com/org/proj/_apis/build/definitions/123"",
+            ""queueStatus"": ""enabled"",
+            ""createdDate"": ""2026-01-01T00:00:00Z"",
+            ""modifiedDate"": ""2026-01-02T00:00:00Z""
+        }
+    ]
+}";
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                if (req.Method == HttpMethod.Get && req.RequestUri!.AbsoluteUri.Contains("/_apis/build/definitions"))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(definitionsJson, Encoding.UTF8, "application/json")
+                    };
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new AzureDevOpsClient(httpClient, organization, project);
+
+            var defs = await client.ListPipelineDefinitionsAsync(project);
+
+            Assert.NotNull(defs);
+            Assert.Single(defs!);
+            var first = defs![0];
+            Assert.Equal("123", first.PlatformId);
+            Assert.Equal("CI", first.Name);
+            Assert.Equal(".github/workflows/ci.yml", first.Path);
+            Assert.Equal("build", first.Type);
+        }
+
+        [Fact]
+        public async Task ListPipelineRunsAsync_ReturnsPipelineRuns()
+        {
+            var organization = "org";
+            var project = "proj";
+
+                        var buildsJson = @"{
+    ""value"": [
+        {
+            ""id"": 456,
+            ""buildNumber"": ""2026.1"",
+            ""status"": ""completed"",
+            ""result"": ""succeeded"",
+            ""sourceBranch"": ""refs/heads/main"",
+            ""queueTime"": ""2026-03-01T00:00:00Z"",
+            ""startTime"": ""2026-03-01T00:01:00Z"",
+            ""finishTime"": ""2026-03-01T00:05:00Z"",
+            ""definition"": { ""id"": 123 },
+            ""logs"": { ""url"": ""https://dev.azure.com/org/proj/_apis/build/builds/456/logs"" },
+            ""url"": ""https://dev.azure.com/org/proj/_build/results?buildId=456""
+        }
+    ]
+}";
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                if (req.Method == HttpMethod.Get && req.RequestUri!.AbsoluteUri.Contains("/_apis/build/builds"))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(buildsJson, Encoding.UTF8, "application/json")
+                    };
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new AzureDevOpsClient(httpClient, organization, project);
+
+            var runs = await client.ListPipelineRunsAsync(project, top: 1);
+
+            Assert.NotNull(runs);
+            Assert.Single(runs!);
+            var run = runs![0];
+            Assert.Equal("456", run.PlatformId);
+            Assert.Equal("2026.1", run.Name);
+            Assert.Contains("main", run.Branch ?? string.Empty);
+            Assert.Equal("completed", run.Status);
+            Assert.Equal("succeeded", run.Result);
+            Assert.Equal("https://dev.azure.com/org/proj/_build/results?buildId=456", run.Url);
+        }
+
+        [Fact]
+        public async Task GetPipelineRunLogsAsync_ReturnsConcatenatedLogs()
+        {
+            var organization = "org";
+            var project = "proj";
+            var buildId = 456;
+
+            var logsListJson = @"{ ""value"": [ { ""id"": 1 }, { ""id"": 2 } ] }";
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                var uri = req.RequestUri!.AbsoluteUri;
+                if (req.Method == HttpMethod.Get && uri.Contains($"/builds/{buildId}/logs?"))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(logsListJson, Encoding.UTF8, "application/json")
+                    });
+                }
+
+                if (req.Method == HttpMethod.Get && uri.Contains($"/builds/{buildId}/logs/1"))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("log entry one", Encoding.UTF8, "text/plain")
+                    });
+                }
+
+                if (req.Method == HttpMethod.Get && uri.Contains($"/builds/{buildId}/logs/2"))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("log entry two", Encoding.UTF8, "text/plain")
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new AzureDevOpsClient(httpClient, organization, project);
+
+            var text = await client.GetPipelineRunLogsAsync(project, buildId);
+
+            Assert.NotNull(text);
+            Assert.Contains("===== Log 1 =====", text);
+            Assert.Contains("log entry one", text);
+            Assert.Contains("===== Log 2 =====", text);
+            Assert.Contains("log entry two", text);
+        }
+    }
+}

--- a/SdoTests/Services/GitHubClientWorkflowTests.cs
+++ b/SdoTests/Services/GitHubClientWorkflowTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+using Sdo.Services;
+
+namespace SdoTests.Services
+{
+    public class GitHubClientWorkflowTests
+    {
+        private class TestHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+            public TestHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            {
+                _responder = responder ?? throw new ArgumentNullException(nameof(responder));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return _responder(request, cancellationToken);
+            }
+        }
+
+        [Fact]
+        public async Task GetWorkflowAsync_ReturnsWorkflow()
+        {
+            var owner = "owner";
+            var repo = "repo";
+            var workflowId = 12345L;
+
+            var workflowJson = $"{{ \"id\": {workflowId}, \"node_id\": \"node123\", \"name\": \"CI\", \"path\": \".github/workflows/ci.yml\", \"state\": \"active\" }}";
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                if (req.Method == HttpMethod.Get && req.RequestUri!.AbsoluteUri.Contains($"/actions/workflows/{workflowId}"))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(workflowJson, Encoding.UTF8, "application/json")
+                    };
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new GitHubClient(httpClient);
+
+            var wf = await client.GetWorkflowAsync(owner, repo, workflowId);
+
+            Assert.NotNull(wf);
+            Assert.Equal(workflowId, wf!.Id);
+            Assert.Equal("CI", wf.Name);
+            Assert.Equal("active", wf.State);
+        }
+
+        [Fact]
+        public async Task TriggerWorkflowAsync_ReturnsTrue_OnNoContent()
+        {
+            var owner = "owner";
+            var repo = "repo";
+            var workflowId = 555L;
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                if (req.Method == HttpMethod.Post && req.RequestUri!.AbsoluteUri.Contains($"/actions/workflows/{workflowId}/dispatches"))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new GitHubClient(httpClient);
+
+            var success = await client.TriggerWorkflowAsync(owner, repo, workflowId, "main");
+            Assert.True(success);
+        }
+
+        [Fact]
+        public async Task GetWorkflowLogsAsync_ReturnsExtractedText()
+        {
+            var owner = "owner";
+            var repo = "repo";
+            var runId = 9999L;
+
+            // Create an in-memory zip stream with a single entry
+            var ms = new MemoryStream();
+            using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
+            {
+                var entry = archive.CreateEntry("logs/job1.txt");
+                using var es = entry.Open();
+                using var sw = new StreamWriter(es, Encoding.UTF8, 1024, leaveOpen: true);
+                sw.Write("hello logs");
+                sw.Flush();
+            }
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var handler = new TestHttpMessageHandler((req, ct) =>
+            {
+                if (req.Method == HttpMethod.Get && req.RequestUri!.AbsoluteUri.Contains($"/actions/runs/{runId}/logs"))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StreamContent(ms)
+                    };
+                    resp.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler);
+            using var client = new GitHubClient(httpClient);
+
+            var text = await client.GetWorkflowLogsAsync(owner, repo, runId);
+
+            Assert.NotNull(text);
+            Assert.Contains("===== logs/job1.txt =====", text);
+            Assert.Contains("hello logs", text);
+        }
+    }
+}

--- a/e2e-tests.targets
+++ b/e2e-tests.targets
@@ -127,4 +127,152 @@
 		<Message Text="Test output log: $(E2ELogFile)" Importance="normal" />
 	</Target>
 
+	<!-- verify-cli-parity moved from nbuild.targets - compares CLI outputs and pipeline commands -->
+	<Target Name="verify-cli-parity" DependsOnTargets="COPY_SDO_EXECUTABLE">
+		<Message Text="========================================" Importance="high" />
+		<Message Text="C# vs Python SDO Output Format Comparison" Importance="high" />
+		<Message Text="========================================" Importance="high" />
+
+		<!-- Command 1: Work Item List -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo workitem list             ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 1a. sdo workitem list (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo workitem list" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 1b. sdo.net.exe wi list (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 1c. sdo workitem list (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo workitem list" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 1d. sdo.net.exe wi list (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi list --verbose" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
+		<!-- Command 2: Work Item Show -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo workitem show --id 1      ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 2a. sdo workitem show --id 1 (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo workitem show --id 1" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 2b. sdo.net.exe wi show --id 1 (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi show --id 1" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 2c. sdo workitem show --id 159 (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo workitem show --id 159" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 2d. sdo.net.exe wi show --id 159 (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi show --id 159" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
+		<!-- Command 3: Pull Request List -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo pr ls                     ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 3a. sdo pr ls (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo pr ls" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 3b. sdo.net.exe pr list (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 3c. sdo pr ls (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo pr ls" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 3d. sdo.net.exe pr list (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
+		<!-- Command 4: Pull Request Status -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo pr status                 ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 4a. sdo pr status 253 (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo pr status 253" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 4b. sdo.net.exe pr status 253 (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr status 253" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 4c. sdo pr status 46 (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo pr status 46" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 4d. sdo.net.exe pr status 46 (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr status 46" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
+		<!-- Command 5: Repository List -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo pr ls --top 5             ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 5a. sdo pr ls --top 5 (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo pr ls --top 5" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 5b. sdo.net.exe repo list --top 5 (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe repo list --top 5" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 5c. sdo pr ls --top 5 (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo pr ls --top 5" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 5d. sdo.net.exe repo list --top 5 (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe repo list --top 5" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
+		<!-- Command 6: Pipeline list -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo pipeline list             ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 6a. sdo pipeline ls (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo pipeline ls" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 6b. sdo.net.exe pipeline list (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 6c. sdo pipeline ls (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo pipeline ls" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 6d. sdo.net.exe pipeline list (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<!-- Summary -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔═════════════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ ✓ Output format and pipeline checks complete    ║" Importance="high" />
+		<Message Text="╚═════════════════════════════════════════════════╝" Importance="high" />
+		<Message Text="" Importance="high" />
+		<Message Text="Pattern: a=Python GitHub | b=C# GitHub | c=Python Azure | d=C# Azure" Importance="high" />
+		<Message Text="Review above to verify parity and pipeline command behavior" Importance="high" />
+	</Target>
+
 </Project>

--- a/e2e-tests.targets
+++ b/e2e-tests.targets
@@ -70,6 +70,11 @@
 		      DestinationFolder="$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\"
 		      SkipUnchangedFiles="true" />
 		<Message Text="✓ sdo.net executable and dependencies copied to test directory" Importance="high" />
+		<!-- Ensure runtimeconfig exists for sdo.net when running tests. Only copy if missing to avoid overwriting test runtimeconfig. -->
+		<Copy SourceFiles="$(SolutionDir)\Sdo\bin\Debug\sdo.net.runtimeconfig.json"
+		      DestinationFiles="$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\sdo.net.runtimeconfig.json"
+		      SkipUnchangedFiles="true"
+		      Condition="!Exists('$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\sdo.net.runtimeconfig.json')" />
 	</Target>
 
 	<!-- Run SDO E2E tests -->

--- a/e2e-tests.targets
+++ b/e2e-tests.targets
@@ -265,6 +265,28 @@
 		<Message Text=">>> 6d. sdo.net.exe pipeline list (C# Azure - ConsoleApp1)" Importance="high" />
 		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
 		
+		<!-- Command 7: Pipeline Logs -->
+		<Message Text="" Importance="high" />
+		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
+		<Message Text="║ Command: sdo pipeline logs             ║" Importance="high" />
+		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 7a. sdo pipeline logs (Python GitHub - ntools)" Importance="high" />
+		<Exec Command="sdo pipeline logs" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 7b. sdo.net.exe pipeline logs (C# GitHub - ntools)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline logs" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 7c. sdo pipeline logs (Python Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="sdo pipeline logs" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+
+		<Message Text="" Importance="high" />
+		<Message Text=">>> 7d. sdo.net.exe pipeline logs (C# Azure - ConsoleApp1)" Importance="high" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline logs --verbose" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+
 		<!-- Summary -->
 		<Message Text="" Importance="high" />
 		<Message Text="╔═════════════════════════════════════════════════╗" Importance="high" />

--- a/e2e-tests.targets
+++ b/e2e-tests.targets
@@ -2,12 +2,129 @@
 
 	<!-- E2E test targets for end-to-end testing -->
 
-	<!-- Placeholder for E2E tests - can be expanded as needed -->
-	<Target Name="E2E" DependsOnTargets="ARTIFACTS">
-		<Message Text="Running E2E tests..." Importance="high" />
-		<!-- Add E2E test execution commands here when E2E tests are implemented -->
-		<Message Text="No E2E tests configured yet" Importance="normal" />
-		<Message Text="E2E tests completed" Importance="high" />
+	<PropertyGroup>
+		<!-- Define any global properties needed for E2E tests here -->
+		<E2ELogFile>$(SolutionDir)e2e-test.log</E2ELogFile> <!-- E2E test log file -->
+	</PropertyGroup>
+	
+	<!-- Delete E2E log file -->
+	<Target Name="DELETE_E2E_LOG" DependsOnTargets="PROPERTIES">
+		<Message Text="Attempting to delete log file: $(E2ELogFile)" Importance="High" />
+		<Message Text="File exists: $([System.IO.File]::Exists('$(E2ELogFile)'))" Importance="High" />
+		<Delete Files="$(E2ELogFile)" ContinueOnError="true">
+			<Output TaskParameter="DeletedFiles" ItemName="DeletedFiles" />
+		</Delete>
+		<Message Text="Deleted log file: $(E2ELogFile)" Importance="High" Condition="'@(DeletedFiles)' != ''" />
+		<Message Text="No log file found to delete" Importance="High" Condition="'@(DeletedFiles)' == ''" />
+	</Target>
+
+	<!-- Build test-framework library -->
+	<Target Name="BUILD_E2E_FRAMEWORK" DependsOnTargets="PROPERTIES">
+		<Message Text="Building test-framework library..." Importance="high" />
+		<Exec Command="dotnet build test-framework\test-framework.csproj --configuration Debug"
+		      WorkingDirectory="$(SolutionDir)"
+		      ContinueOnError="false" />
+		<Message Text="✓ test-framework built successfully" Importance="high" />
+	</Target>
+
+	<!-- Build Sdo executable -->
+	<Target Name="BUILD_SDO_E2E" DependsOnTargets="BUILD_E2E_FRAMEWORK">
+		<Message Text="Building Sdo.net executable..." Importance="high" />
+		<Exec Command="dotnet build Sdo\Sdo.csproj --configuration Debug"
+		      WorkingDirectory="$(SolutionDir)"
+		      ContinueOnError="false" />
+		<Message Text="✓ Sdo.net executable built successfully" Importance="high" />
+	</Target>
+
+	<!-- Build sdo-e2e-test executable -->
+	<Target Name="BUILD_SDO_E2E_TESTS" DependsOnTargets="BUILD_SDO_E2E">
+		<Message Text="Building sdo-e2e-test executable..." Importance="high" />
+		<Exec Command="dotnet build sdo-e2e-test\sdo-e2e-test.csproj --configuration Debug"
+		      WorkingDirectory="$(SolutionDir)"
+		      ContinueOnError="false" />
+		<Message Text="✓ sdo-e2e-test executable built successfully" Importance="high" />
+	</Target>
+
+	<!-- Copy sdo.net executable to test output directory -->
+	<Target Name="COPY_SDO_EXECUTABLE" DependsOnTargets="BUILD_SDO_E2E_TESTS">
+		<Message Text="Copying sdo.net executable and all required dependencies to test output directory..." Importance="high" />
+		<ItemGroup>
+			<!-- Copy sdo.net and its dependencies -->
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\sdo.net.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\nb.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\NbuildTasks.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\GitHubRelease.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\Launcher.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\System.Configuration.ConfigurationManager.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\System.Diagnostics.EventLog.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\System.Security.Cryptography.Pkcs.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\System.Security.Cryptography.ProtectedData.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\Microsoft.Build.Framework.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\Microsoft.Build.Utilities.Core.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\Microsoft.NET.StringTools.dll" />
+			<SdoFiles Include="$(SolutionDir)\Sdo\bin\Debug\sdo.net.deps.json" />
+			<!-- NOTE: Do NOT copy sdo.net.runtimeconfig.json as it will overwrite sdo-e2e-test.runtimeconfig.json -->
+		</ItemGroup>
+		<Copy SourceFiles="@(SdoFiles)"
+		      DestinationFolder="$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\"
+		      SkipUnchangedFiles="true" />
+		<Message Text="✓ sdo.net executable and dependencies copied to test directory" Importance="high" />
+	</Target>
+
+	<!-- Run SDO E2E tests -->
+	<Target Name="RUN_SDO_E2E_TESTS" DependsOnTargets="COPY_SDO_EXECUTABLE">
+		<Message Text="Running SDO E2E tests..." Importance="high" />
+		<PropertyGroup>
+			<SdoE2eTestExe>.\sdo-e2e-test.exe</SdoE2eTestExe>
+			<SdoE2eTestDir>$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\</SdoE2eTestDir>
+		</PropertyGroup>
+		<Exec Command="$(SdoE2eTestExe) test --verbose"
+		      WorkingDirectory="$(SdoE2eTestDir)"
+		      EnvironmentVariables="SOLUTION_DIR=$(SolutionDir)" />
+		<Message Text="✓ SDO E2E tests completed" Importance="high" />
+	</Target>
+
+	<!-- Run GitHub Pipeline Creation test -->
+	<Target Name="RUN_GITHUB_PIPELINE_TEST" DependsOnTargets="COPY_SDO_EXECUTABLE">
+		<Message Text="Running GitHub Pipeline Creation test..." Importance="high" />
+		<PropertyGroup>
+			<SdoE2eTestExe>.\sdo-e2e-test.exe</SdoE2eTestExe>
+			<SdoE2eTestDir>$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\</SdoE2eTestDir>
+		</PropertyGroup>
+		<Exec Command="$(SdoE2eTestExe) test --verbose --test-case PipelineCreate_GitHub_CreateAndVerify"
+		      WorkingDirectory="$(SdoE2eTestDir)"
+		      EnvironmentVariables="SOLUTION_DIR=$(SolutionDir)" />
+		<Message Text="✓ GitHub Pipeline Creation test completed" Importance="high" />
+	</Target>
+
+	<!-- Run Azure DevOps Pipeline Creation test -->
+	<Target Name="RUN_AZDO_PIPELINE_TEST" DependsOnTargets="COPY_SDO_EXECUTABLE">
+		<Message Text="Running Azure DevOps Pipeline Creation test..." Importance="high" />
+		<PropertyGroup>
+			<SdoE2eTestExe>.\sdo-e2e-test.exe</SdoE2eTestExe>
+			<SdoE2eTestDir>$(SolutionDir)\sdo-e2e-test\bin\Debug\net10.0\</SdoE2eTestDir>
+		</PropertyGroup>
+		<Exec Command="$(SdoE2eTestExe) test --verbose --test-case PipelineCreate_AzureDevOps_CreateAndVerify"
+		      WorkingDirectory="$(SdoE2eTestDir)"
+		      EnvironmentVariables="SOLUTION_DIR=$(SolutionDir)" />
+		<Message Text="✓ Azure DevOps Pipeline Creation test completed" Importance="high" />
+	</Target>
+
+	<!-- Main E2E Pipeline target - runs both pipeline creation tests -->
+	<Target Name="E2E_PIPELINES" DependsOnTargets="ARTIFACTS;DELETE_E2E_LOG;RUN_GITHUB_PIPELINE_TEST;RUN_AZDO_PIPELINE_TEST">
+		<Message Text="======================================" Importance="high" />
+		<Message Text="✓ All Pipeline Creation tests completed successfully" Importance="high" />
+		<Message Text="======================================" Importance="high" />
+		<Message Text="Test output log: $(E2ELogFile)" Importance="normal" />
+	</Target>
+
+	<!-- Main E2E target - builds and runs all E2E tests -->
+	<Target Name="E2E" DependsOnTargets="ARTIFACTS;DELETE_E2E_LOG;RUN_SDO_E2E_TESTS">
+		<Message Text="======================================" Importance="high" />
+		<Message Text="✓ All E2E tests completed successfully" Importance="high" />
+		<Message Text="======================================" Importance="high" />
+		<Message Text="Test output log: $(E2ELogFile)" Importance="normal" />
 	</Target>
 
 </Project>

--- a/lf/lf.csproj
+++ b/lf/lf.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -6,6 +6,10 @@
 	<Import Project="unit-tests.targets"/>
 	<Import Project="e2e-tests.targets"/>
 
+	<!-- Update documentation versions from JSON configuration files -->
+	<UsingTask TaskName="NbuildTasks.UpdateVersionsInDocs" AssemblyFile="C:\source\ntools\Release\NbuildTasks.dll" />
+	<UsingTask TaskName="NbuildTasks.GenerateCommitMessage" AssemblyFile="C:\source\ntools\Release\NbuildTasks.dll" />
+
 	<PropertyGroup>
 		<!-- This is the folder where the *.sln resides-->
 		<DeploymentFolder>$(ProgramFiles)\Nbuild</DeploymentFolder>
@@ -55,7 +59,6 @@
 		<Message Text="==> DONE"/>
 	</Target>
 
-		
 	<!-- Test for FileVersion task and powershell file-version.ps1-->
 	<Target Name="FILE_VERSIONS"  DependsOnTargets="ARTIFACTS">
 		<PropertyGroup>
@@ -127,14 +130,13 @@
 		<Message Text="==> DONE" />
 	</Target>
 
-  <!-- Run nbTests and generate code coverage report -->
-  <Target Name="RUN_NBTESTS_COVERAGE" DependsOnTargets="INSTALL_REPORTGENERATOR">
+	<!-- Run nbTests and generate code coverage report -->
+	<Target Name="RUN_NBTESTS_COVERAGE" DependsOnTargets="INSTALL_REPORTGENERATOR">
 	<Exec Command="dotnet test &quot;$(SolutionDir)\nbTests\nbTests.csproj&quot; --collect:\&quot;XPlat Code Coverage\&quot;" WorkingDirectory="$(SolutionDir)" />
 	<Exec Command="&quot;$(ReportGeneratorExe)&quot; -reports:$(SolutionDir)\TestResults\**\coverage.cobertura.xml -targetdir:$(SolutionDir)\TestResults\CoverageReport" />
 	<Message Text="nbTests executed and code coverage report generated in TestResults\CoverageReport." />
 	<Message Text="==> DONE" />
   </Target>
-
 
 	<!-- mkdocs deploy locally -->
 	<Target Name="MKDOCS_DEPLOY" AfterTargets="MKDOCS">
@@ -222,7 +224,6 @@
 		<Message Text="==> DONE"/>
 	</Target>
 
-
 	<!-- Build the solution alias solution target -->
     <Target Name="BUILD" >
         <CallTarget Targets="solution" />
@@ -239,133 +240,6 @@
 		</PropertyGroup>
 		<Message Text="API_GITHUB_KEY length: $(GitHubKeyLength)" Condition="'$(API_GITHUB_KEY)' != ''" Importance="high" />
 		<Message Text="==> CHECK_GITHUB_KEY done" Importance="high" />
-	</Target>
-
-	<!-- Test sdo.net.exe output format from ntools and ConsoleApp1 -->
-		<!-- Test sdo.net.exe output format from ntools and ConsoleApp1 -->
-	<Target Name="current-test" DependsOnTargets="BUILD">
-		<Message Text="========================================" Importance="high" />
-		<Message Text="C# vs Python SDO Output Format Comparison" Importance="high" />
-		<Message Text="========================================" Importance="high" />
-
-		<!-- Command 1: Work Item List -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ Command: sdo workitem list             ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 1a. sdo workitem list (Python GitHub - ntools)" Importance="high" />
-		<Exec Command="sdo workitem list" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 1b. sdo.net.exe wi list (C# GitHub - ntools)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe wi list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 1c. sdo workitem list (Python Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="sdo workitem list" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 1d. sdo.net.exe wi list (C# Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe wi list --verbose" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
-
-		<!-- Command 2: Work Item Show -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ Command: sdo workitem show --id 1      ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 2a. sdo workitem show --id 1 (Python GitHub - ntools)" Importance="high" />
-		<Exec Command="sdo workitem show --id 1" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 2b. sdo.net.exe wi show --id 1 (C# GitHub - ntools)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe wi show --id 1" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 2c. sdo workitem show --id 159 (Python Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="sdo workitem show --id 159" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 2d. sdo.net.exe wi show --id 159 (C# Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe wi show --id 159" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
-
-		<!-- Command 3: Pull Request List -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ Command: sdo pr ls                     ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 3a. sdo pr ls (Python GitHub - ntools)" Importance="high" />
-		<Exec Command="sdo pr ls" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 3b. sdo.net.exe pr list (C# GitHub - ntools)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe pr list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 3c. sdo pr ls (Python Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="sdo pr ls" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 3d. sdo.net.exe pr list (C# Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe pr list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
-
-		<!-- Command 4: Pull Request Status -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ Command: sdo pr status                 ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 4a. sdo pr status 253 (Python GitHub - ntools)" Importance="high" />
-		<Exec Command="sdo pr status 253" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 4b. sdo.net.exe pr status 253 (C# GitHub - ntools)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe pr status 253" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 4c. sdo pr status 46 (Python Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="sdo pr status 46" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 4d. sdo.net.exe pr status 46 (C# Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe pr status 46" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
-
-		<!-- Command 5: Repository List -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ Command: sdo pr ls --top 5             ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 5a. sdo pr ls --top 5 (Python GitHub - ntools)" Importance="high" />
-		<Exec Command="sdo pr ls --top 5" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 5b. sdo.net.exe repo list --top 5 (C# GitHub - ntools)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe repo list --top 5" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 5c. sdo pr ls --top 5 (Python Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="sdo pr ls --top 5" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
-
-		<Message Text="" Importance="high" />
-		<Message Text=">>> 5d. sdo.net.exe repo list --top 5 (C# Azure - ConsoleApp1)" Importance="high" />
-		<Exec Command="$(SolutionDir)\Sdo\bin\Release\sdo.net.exe repo list --top 5" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
-
-		<!-- Summary -->
-		<Message Text="" Importance="high" />
-		<Message Text="╔════════════════════════════════════════╗" Importance="high" />
-		<Message Text="║ ✓ Output format comparison complete    ║" Importance="high" />
-		<Message Text="╚════════════════════════════════════════╝" Importance="high" />
-		<Message Text="" Importance="high" />
-		<Message Text="Pattern: a=Python GitHub | b=C# GitHub | c=Python Azure | d=C# Azure" Importance="high" />
-		<Message Text="Review above to verify C# matches Python format on both platforms" Importance="high" />
 	</Target>
 
 	<!-- Update ntools locally for testing -->
@@ -437,9 +311,6 @@
 		<Message Text="==> DONE"/>
 	</Target>
 
-	<!-- Update documentation versions from JSON configuration files -->
-	<UsingTask TaskName="NbuildTasks.UpdateVersionsInDocs" AssemblyFile="C:\source\ntools\Release\NbuildTasks.dll" />
-	<UsingTask TaskName="NbuildTasks.GenerateCommitMessage" AssemblyFile="C:\source\ntools\Release\NbuildTasks.dll" />
 	
 	<Target Name="UPDATE_DOC_VERSIONS" DependsOnTargets="PROPERTIES">
 		<UpdateVersionsInDocs 

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -4,6 +4,7 @@
 	
 	<Import Project="$(ProgramFiles)\Nbuild\common.targets"/>
 	<Import Project="unit-tests.targets"/>
+	<Import Project="e2e-tests.targets"/>
 
 	<PropertyGroup>
 		<!-- This is the folder where the *.sln resides-->
@@ -808,6 +809,18 @@
 			<SdoSourceDir>$(SolutionDir)\atools</SdoSourceDir>
 		</PropertyGroup>
 
+		<!-- Install SDO dependencies first -->
+		<Message Text="Installing SDO dependencies..." Importance="high" />
+		<Exec Command='$(PythonExe) -m pip install requests click pyyaml' ContinueOnError="true" />
+
+		<!-- Build and install SDO in development mode to generate executable -->
+		<Message Text="Building SDO executable using pip install -e..." Importance="high" />
+		<Exec Command='$(PythonExe) -m pip install -e "$(SdoSourceDir)"' />
+
+		<!-- Use Python to find and copy sdo.exe -->
+		<Message Text="Locating and copying SDO executable..." Importance="high" />
+		<Exec Command='$(PythonExe) -c "import shutil, sysconfig, os; scripts = sysconfig.get_path(&apos;scripts&apos;); src = os.path.join(scripts, &apos;sdo.exe&apos;); dst = os.path.join(&apos;$(ArtifactsFolder)&apos;, &apos;sdo.exe&apos;); os.path.exists(src) and shutil.copy2(src, dst) or print(f&apos;Warning: sdo.exe not found at {src}&apos;)"' ContinueOnError="true" />
+
 		<!-- Copy SDO installation script and documentation -->
 		<Message Text="Copying SDO installation files..." Importance="high" />
 		<Copy SourceFiles="$(SdoSourceDir)\install-sdo.py" DestinationFiles="$(ArtifactsFolder)\install-sdo.py" />
@@ -820,7 +833,7 @@
 		</ItemGroup>
 		<Copy SourceFiles="@(SdoPackageFiles)" DestinationFiles="@(SdoPackageFiles->'$(ArtifactsFolder)\sdo_package\%(RecursiveDir)%(Filename)%(Extension)')" />
 
-		<Message Text="SDO package built successfully with virtual environment installer" Importance="high" />
+		<Message Text="SDO package built successfully with executable" Importance="high" />
 		<Message Text="==> BUILD_SDO DONE"/>
 	</Target>
 

--- a/ntools.sln
+++ b/ntools.sln
@@ -19,7 +19,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nbuild.targets = nbuild.targets
 		prebuild.bat = prebuild.bat
 		README.md = README.md
-		sdo-e2e-test\sdo-e2e-test.csproj = sdo-e2e-test\sdo-e2e-test.csproj
 		targets.md = targets.md
 	EndProjectSection
 EndProject
@@ -117,10 +116,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nBackup", "nBackup\nBackup.csproj", "{75AF1D68-CD4A-4C01-9728-7A93B8DDEA1B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiVersions", "ApiVersions\ApiVersions.csproj", "{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-framework", "test-framework\test-framework.csproj", "{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sdo-e2e-test", "sdo-e2e-test\sdo-e2e-test.csproj", "{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -288,30 +283,6 @@ Global
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x64.Build.0 = Release|Any CPU
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x86.Build.0 = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x64.Build.0 = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x86.Build.0 = Debug|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x64.ActiveCfg = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x64.Build.0 = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x86.ActiveCfg = Release|Any CPU
-		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x86.Build.0 = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x64.Build.0 = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x86.Build.0 = Debug|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x64.ActiveCfg = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x64.Build.0 = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x86.ActiveCfg = Release|Any CPU
-		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ntools.sln
+++ b/ntools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.3.11520.95 d18.3
+VisualStudioVersion = 18.3.11520.95
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{80B7EE8D-BFD5-4F31-BC37-103FDDACEA23}"
 EndProject
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nbuild.targets = nbuild.targets
 		prebuild.bat = prebuild.bat
 		README.md = README.md
+		sdo-e2e-test\sdo-e2e-test.csproj = sdo-e2e-test\sdo-e2e-test.csproj
 		targets.md = targets.md
 	EndProjectSection
 EndProject
@@ -116,6 +117,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nBackup", "nBackup\nBackup.csproj", "{75AF1D68-CD4A-4C01-9728-7A93B8DDEA1B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiVersions", "ApiVersions\ApiVersions.csproj", "{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-framework", "test-framework\test-framework.csproj", "{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sdo-e2e-test", "sdo-e2e-test\sdo-e2e-test.csproj", "{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -283,6 +288,30 @@ Global
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x64.Build.0 = Release|Any CPU
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{71123CA7-06B4-BEC1-ED29-A55FCC7F22BB}.Release|x86.Build.0 = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Debug|x86.Build.0 = Debug|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x64.Build.0 = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{377DD93F-07C5-D1F7-E595-70AC1B5BC6AC}.Release|x86.Build.0 = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x64.Build.0 = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A5E84C5-475B-C1BC-6AAB-2629E088CD0B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/unit-tests.targets
+++ b/unit-tests.targets
@@ -87,6 +87,20 @@
         <Message Text="Unit tests for RepositoryCommand complete." />
     </Target>
 
+    <!-- Unit tests for PipelineCommand -->
+    <Target Name="UNIT_TEST_PIPELINE_COMMAND">
+        <Message Text="Running unit tests for PipelineCommand..." />
+        <Exec Command='dotnet test "$(SolutionDir)\SdoTests\SdoTests.csproj" --filter "FullyQualifiedName~PipelineCommandTests" --logger trx' WorkingDirectory="$(SolutionDir)" />
+        <Message Text="Unit tests for PipelineCommand complete." />
+    </Target>
+
+    <!-- Ad hoc integration-style test for AzureDevOpsClient.GetPipelineAsync -->
+    <Target Name="UNIT_TEST_ADHOC_GET_PIPELINE_ASYNC">
+        <Message Text="Running ad hoc test for AzureDevOpsClient.GetPipelineAsync..." />
+        <Exec Command='dotnet test "$(SolutionDir)\SdoTests\SdoTests.csproj" --filter "FullyQualifiedName~AdHoc_GetPipelineAsync_WithConfiguredEnvironment_ReturnsPipeline" --logger trx' WorkingDirectory="$(SolutionDir)" />
+        <Message Text="Ad hoc GetPipelineAsync test complete." />
+    </Target>
+
     <!-- Unit tests for PullRequestCommand -->
     <Target Name="UNIT_TEST_PULL_REQUEST_COMMAND">
         <Message Text="Running unit tests for PullRequestCommand..." />
@@ -116,7 +130,7 @@
     </Target>
 
     <!-- Run all unit tests -->
-    <Target Name="UNIT_TEST_ALL" DependsOnTargets="UNIT_TEST_CLI_VALIDATION;UNIT_TEST_BUILD_STARTER;UNIT_TEST_CLI;UNIT_TEST_COMMAND;UNIT_TEST_NB_COMMAND;UNIT_TEST_GIT_CLONE_COMMAND;UNIT_TEST_NTOOLS_JSON;UNIT_TEST_RELEASE_SERVICE_FACTORY;UNIT_TEST_RESOURCE_HELPER;UNIT_TEST_WORKITEM_COMMAND;UNIT_TEST_WORKITEM_STATE_TRANSLATOR">
+    <Target Name="UNIT_TEST_ALL" DependsOnTargets="UNIT_TEST_CLI_VALIDATION;UNIT_TEST_BUILD_STARTER;UNIT_TEST_CLI;UNIT_TEST_COMMAND;UNIT_TEST_NB_COMMAND;UNIT_TEST_GIT_CLONE_COMMAND;UNIT_TEST_NTOOLS_JSON;UNIT_TEST_RELEASE_SERVICE_FACTORY;UNIT_TEST_RESOURCE_HELPER;UNIT_TEST_WORKITEM_COMMAND;UNIT_TEST_PIPELINE_COMMAND;UNIT_TEST_WORKITEM_STATE_TRANSLATOR">
         <Message Text="All unit tests completed." />
     </Target>
 


### PR DESCRIPTION
Implement API-driven pipeline command infrastructure for both GitHub Actions and Azure DevOps platforms.

## Changes

### Core Commands
- **PipelineCommand**: New command with all 9 subcommands (create, delete, lastbuild, list, logs, run, show, status, update)
  - Platform auto-detection (GitHub vs Azure DevOps)
  - Consistent error handling with text-based indicators
  - Verbose mode showing equivalent gh/az CLI commands

### API Integration

**GitHub (CreateWorkflowAsync)**
- Repository validation via GitHub API GET /repos/{owner}/{repo}
- YAML file validation (exists, not empty, proper extension)
- Returns bool indicating if workflow can be created
- Workflows created via git commit/push to .github/workflows/

**Azure DevOps (CreatePipelineAsync)**
- REST API POST to /_apis/build/definitions
- Returns actual pipeline ID on success
- Full error handling and diagnostics via LastError property
- Comprehensive request payload with YAML filename and repository info

### Service Enhancements
- **AzureDevOpsCredentials**: New centralized service for token management
- **GitHubClient**: Extended with CreateWorkflowAsync() method
- **AzureDevOpsClient**: Extended with CreatePipelineAsync() method
- **PlatformService**: Enhanced for pipeline-specific routing

### Testing
- **PipelineCommandTests**: 31+ unit tests covering:
  - All 9 subcommands (structure, arguments, options)
  - Platform-specific handlers
  - Error cases (invalid files, bad extensions, missing args)
  - Command registration and ordering

### Currently Working
✅ `sdo.net pipeline show` - Display pipelines/workflows
✅ `sdo.net pipeline list` - List with optional --repo filtering  
✅ `sdo.net pipeline create` - Create with API-driven creation
✅ `sdo.net pipeline delete` - Delete with confirmation
✅ `sdo.net pipeline lastbuild` - Show recent builds/runs

## Testing
- Unit tests: `nb UNIT_TEST_PIPELINE_COMMAND` - 31+ tests passing
- E2E tests: `nb e2e_pipelines` - GitHub & Azure DevOps integration tests (2/2 passing)

## Related Issues
Closes #243

## Notes
- Create command supports both platforms: GitHub (API validation) and Azure DevOps (direct API creation)
- All handlers follow existing command patterns in the SDK
- Credentials managed centrally via environment variables (GITHUB_TOKEN, AZURE_DEVOPS_PAT)
- Platform detection automatic from git remote