### PR TITLE
243: ## Implement user commands, mapping fixes, docs and E2E parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,5 @@ docs/todo.md
 /build-errors.txt
 /test-pipeline.txt
 /test-workflow.yml
+/test-framework
+/sdo-e2e-test

--- a/Sdo/Commands/UserCommand.cs
+++ b/Sdo/Commands/UserCommand.cs
@@ -1,0 +1,399 @@
+using System;
+using System.CommandLine;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nbuild.Helpers;
+using Sdo.Interfaces;
+using Sdo.Services;
+
+namespace Sdo.Commands
+{
+    /// <summary>
+    /// User management commands (GitHub & Azure DevOps).
+    /// Follows the same pattern as other commands (detect platform, get token, call client).
+    /// Reference: Python implementation available under c:\source\saz for behavior details.
+    /// </summary>
+    public class UserCommand : Command
+    {
+        private readonly PlatformService _platformDetector;
+
+        public UserCommand(Option<bool> verboseOption) : base("user", "User management commands for GitHub and Azure DevOps")
+        {
+            _platformDetector = new PlatformService();
+
+            AddShowCommand(verboseOption);
+            AddListCommand(verboseOption);
+            AddSearchCommand(verboseOption);
+            AddPermissionsCommand(verboseOption);
+        }
+
+        private void AddShowCommand(Option<bool> verboseOption)
+        {
+            var cmd = new Command("show", "Show user details (by login or id)");
+            var loginOpt = new Option<string?>("--login") { Description = "User login or id" };
+            cmd.Add(loginOpt);
+            cmd.Add(verboseOption);
+            cmd.SetAction(async (pr) =>
+            {
+                var login = pr.GetValue(loginOpt);
+                var verbose = pr.GetValue(verboseOption);
+                return await ShowUser(login, verbose);
+            });
+            Subcommands.Add(cmd);
+        }
+
+        private void AddListCommand(Option<bool> verboseOption)
+        {
+            var cmd = new Command("list", "List users/collaborators in the current repository or organization");
+            var topOpt = new Option<int>("--top") { Description = "Limit results" };
+            cmd.Add(topOpt);
+            cmd.Add(verboseOption);
+            cmd.SetAction(async (pr) =>
+            {
+                var top = pr.GetValue(topOpt);
+                var verbose = pr.GetValue(verboseOption);
+                return await ListUsers(top, verbose);
+            });
+            Subcommands.Add(cmd);
+        }
+
+        private void AddSearchCommand(Option<bool> verboseOption)
+        {
+            var cmd = new Command("search", "Search users by name or email (GitHub only)");
+            var qOpt = new Option<string?>("--query") { Description = "Search query (name, email, login)" };
+            cmd.Add(qOpt);
+            cmd.Add(verboseOption);
+            cmd.SetAction(async (pr) =>
+            {
+                var q = pr.GetValue(qOpt);
+                var verbose = pr.GetValue(verboseOption);
+                return await SearchUsers(q, verbose);
+            });
+            Subcommands.Add(cmd);
+        }
+
+        private void AddPermissionsCommand(Option<bool> verboseOption)
+        {
+            var cmd = new Command("permissions", "Show permissions for a user or current identity (org/project)");
+            var userOpt = new Option<string?>("--user") { Description = "User login or id" };
+            cmd.Add(userOpt);
+            cmd.Add(verboseOption);
+            cmd.SetAction(async (pr) =>
+            {
+                var user = pr.GetValue(userOpt);
+                var verbose = pr.GetValue(verboseOption);
+                return await ShowPermissions(user, verbose);
+            });
+            Subcommands.Add(cmd);
+        }
+
+        private async Task<int> ShowUser(string? login, bool verbose)
+        {
+            try
+            {
+                var platform = _platformDetector.DetectPlatform();
+                if (verbose) ConsoleHelper.WriteLine($"Detected platform: {platform}", ConsoleColor.Green);
+
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        var mappingGen = new Sdo.Mapping.MappingGenerator();
+                            var repo = _platformDetector.GetRepositoryInfo();
+                            if (repo != null && !string.IsNullOrEmpty(repo.Owner) && !string.IsNullOrEmpty(repo.Repo))
+                            {
+                                var mappingCmd = mappingGen.CollaboratorsListGitHub(repo.Owner, repo.Repo, 100);
+                                if (!string.IsNullOrEmpty(mappingCmd)) ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                            }
+                    }
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetGitHubTokenAsync();
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        ConsoleHelper.WriteLine("X No GitHub token found", ConsoleColor.Red);
+                        return 1;
+                    }
+                    var client = new GitHubClient(token);
+                    if (string.IsNullOrEmpty(login))
+                    {
+                        var user = await client.GetUserAsync();
+                        if (user == null) { ConsoleHelper.WriteLine("X User not found", ConsoleColor.Red); return 1; }
+                        Console.WriteLine($"User: {user.Login} — {user.Name}");
+                        return 0;
+                    }
+                    var found = await client.GetUserAsync(login);
+                    if (found == null) { ConsoleHelper.WriteLine("X User not found", ConsoleColor.Red); return 1; }
+                    Console.WriteLine($"User: {found.Login} — {found.Name}");
+                    return 0;
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    if (verbose)
+                    {
+                        var mappingGen = new Sdo.Mapping.MappingGenerator();
+                        var mappingOrg = _platformDetector.GetOrganization() ?? "(organization)";
+                        var mappingProject = _platformDetector.GetProject() ?? "(project)";
+                        var mappingCmd = mappingGen.ListUsersAzure(mappingOrg, mappingProject, 1000);
+                        if (!string.IsNullOrEmpty(mappingCmd)) ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                    }
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetAzureDevOpsTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No Azure DevOps PAT found", ConsoleColor.Red); return 1; }
+                    var org = _platformDetector.GetOrganization();
+                    if (string.IsNullOrEmpty(org)) { ConsoleHelper.WriteLine("X Could not determine organization", ConsoleColor.Red); return 1; }
+                    var client = new AzureDevOpsClient(token, org);
+                    // Azure DevOps user lookup placeholder — implementation depends on Graph APIs
+                    var user = await client.GetUserAsync(login);
+                    if (user == null) { ConsoleHelper.WriteLine("X User not found", ConsoleColor.Red); return 1; }
+                    Console.WriteLine($"User: {user.DisplayName} — {user.UniqueName}");
+                    return 0;
+                }
+                else
+                {
+                    ConsoleHelper.WriteLine("X Unsupported platform", ConsoleColor.Red);
+                    return 1;
+                }
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteLine($"X Error: {ex.Message}", ConsoleColor.Red);
+                return 1;
+            }
+        }
+
+        private async Task<int> ListUsers(int top, bool verbose)
+        {
+            try
+            {
+                var platform = _platformDetector.DetectPlatform();
+                // When verbose, show equivalent native CLI mapping (gh / az)
+                if (verbose)
+                {
+                    var mappingGen = new Sdo.Mapping.MappingGenerator();
+                    if (platform == Platform.GitHub)
+                    {
+                        var repo = _platformDetector.GetRepositoryInfo();
+                        if (repo != null && !string.IsNullOrEmpty(repo.Owner) && !string.IsNullOrEmpty(repo.Repo))
+                        {
+                            var mappingCmd = mappingGen.CollaboratorsListGitHub(repo.Owner, repo.Repo, top > 0 ? top : 100);
+                            if (!string.IsNullOrEmpty(mappingCmd)) ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                        }
+                    }
+                    else if (platform == Platform.AzureDevOps)
+                    {
+                        var mappingOrg = _platformDetector.GetOrganization() ?? "(organization)";
+                        var mappingProject = _platformDetector.GetProject() ?? "(project)";
+                        var mappingCmd = mappingGen.ListUsersAzure(mappingOrg, mappingProject, top > 0 ? top : 1000);
+                        if (!string.IsNullOrEmpty(mappingCmd)) ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                    }
+                }
+                if (platform == Platform.GitHub)
+                {
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetGitHubTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No GitHub token found", ConsoleColor.Red); return 1; }
+                    var client = new GitHubClient(token);
+                    var repo = _platformDetector.GetRepositoryInfo();
+                    if (repo == null) { ConsoleHelper.WriteLine("X Could not determine repository", ConsoleColor.Red); return 1; }
+
+                    if (verbose)
+                    {
+                        // show mapping
+                    }
+
+                    var collabs = await client.ListCollaboratorsAsync(repo.Owner!, repo.Repo!, top > 0 ? top : 100);
+                    if (collabs == null || collabs.Count == 0) { Console.WriteLine("No users found"); return 0; }
+
+                    // Header similar to saz output
+                    ConsoleHelper.WriteLine($"Users in repository '{repo.Owner}/{repo.Repo}' ({collabs.Count} total):", ConsoleColor.Green);
+                    Console.WriteLine(new string('-', 80));
+                    foreach (var c in collabs)
+                    {
+                        var name = string.IsNullOrEmpty(c.Name) ? "(no display name)" : c.Name;
+                        Console.WriteLine($"  {name} — {c.Login}");
+                    }
+                    Console.WriteLine();
+                    return 0;
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetAzureDevOpsTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No Azure DevOps PAT found", ConsoleColor.Red); return 1; }
+                    var org = _platformDetector.GetOrganization();
+                    if (string.IsNullOrEmpty(org)) { ConsoleHelper.WriteLine("X Could not determine organization", ConsoleColor.Red); return 1; }
+                    var client = new AzureDevOpsClient(token, org);
+                    var project = _platformDetector.GetProject();
+
+
+                    if (verbose)
+                    {
+                        // show mapping
+                    }
+
+                    var users = await client.ListUsersAsync(top > 0 ? top : 1000);
+                    if (users == null || users.Count == 0) { Console.WriteLine("No users found"); return 0; }
+
+                    // Print extracted info and a friendly header like the Python saz output
+                    ConsoleHelper.WriteLine("✓ Extracted Azure DevOps information from Git remote:", ConsoleColor.Green);
+                    Console.WriteLine($"  Organization: {org}");
+                    Console.WriteLine($"  Project: {project}");
+                    Console.WriteLine();
+
+                    Console.WriteLine($"Users in organization '{org}' ({users.Count} total):");
+                    Console.WriteLine(new string('-', 80));
+                    foreach (var u in users)
+                    {
+                        Console.WriteLine("---");
+                        if (!string.IsNullOrEmpty(u.DisplayName)) Console.WriteLine($"DisplayName: {u.DisplayName}");
+                        if (!string.IsNullOrEmpty(u.UniqueName)) Console.WriteLine($"UniqueName: {u.UniqueName}");
+
+                        // Try to extract a GUID-like id from descriptor or show a shortened descriptor
+                        if (!string.IsNullOrEmpty(u.Id))
+                        {
+                            var id = u.Id;
+                            // regex for GUID
+                            var guidMatch = System.Text.RegularExpressions.Regex.Match(id, "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+                            if (guidMatch.Success)
+                            {
+                                Console.WriteLine($"Id: {guidMatch.Value}");
+                            }
+                            else
+                            {
+                                // Truncate long service descriptors to keep output readable
+                                if (id.Length > 48)
+                                {
+                                    var shortId = id.Substring(0, 24) + "..." + id.Substring(id.Length - 12);
+                                    Console.WriteLine($"Descriptor: {shortId}");
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"Descriptor: {id}");
+                                }
+                            }
+                        }
+
+                        Console.WriteLine();
+                    }
+                    Console.WriteLine(new string('-', 80));
+                    return 0;
+                }
+                ConsoleHelper.WriteLine("X Unsupported platform", ConsoleColor.Red);
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteLine($"X Error: {ex.Message}", ConsoleColor.Red);
+                return 1;
+            }
+        }
+
+        private async Task<int> SearchUsers(string? query, bool verbose)
+        {
+            if (string.IsNullOrEmpty(query))
+            {
+                ConsoleHelper.WriteLine("X Query is required for search", ConsoleColor.Red);
+                return 1;
+            }
+            try
+            {
+                var platform = _platformDetector.DetectPlatform();
+                if (platform == Platform.GitHub)
+                {
+                    if (verbose)
+                    {
+                        var mappingGen = new Sdo.Mapping.MappingGenerator();
+                        var mappingCmd = mappingGen.SearchUsersGitHub(query, 100);
+                        if (!string.IsNullOrEmpty(mappingCmd)) ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                    }
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetGitHubTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No GitHub token found", ConsoleColor.Red); return 1; }
+                    var client = new GitHubClient(token);
+                    var results = await client.SearchUsersAsync(query);
+                    if (results == null || results.Count == 0) { Console.WriteLine("No users found"); return 0; }
+                    foreach (var r in results) Console.WriteLine($"{r.Login} — {r.Name}");
+                    return 0;
+                }
+                else
+                {
+                    ConsoleHelper.WriteLine("X Search is only supported for GitHub in this version", ConsoleColor.Yellow);
+                    return 1;
+                }
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteLine($"X Error: {ex.Message}", ConsoleColor.Red);
+                return 1;
+            }
+        }
+
+        private async Task<int> ShowPermissions(string? user, bool verbose)
+        {
+            try
+            {
+                var platform = _platformDetector.DetectPlatform();
+                // When verbose, show equivalent native CLI mapping (gh / az)
+                if (verbose)
+                {
+                    var mappingGen = new Sdo.Mapping.MappingGenerator();
+                    string mappingCmd = string.Empty;
+                    if (platform == Platform.GitHub)
+                    {
+                        var repo = _platformDetector.GetRepositoryInfo();
+                        if (repo != null && !string.IsNullOrEmpty(repo.Owner) && !string.IsNullOrEmpty(repo.Repo))
+                        {
+                            mappingCmd = mappingGen.RepoPermissionGitHub(repo.Owner, repo.Repo, user ?? "<user>");
+                        }
+                    }
+                    else if (platform == Platform.AzureDevOps)
+                    {
+                        var org = _platformDetector.GetOrganization() ?? "(organization)";
+                        var project = _platformDetector.GetProject() ?? "(project)";
+                        mappingCmd = mappingGen.UserPermissionsAzure(org, project, user ?? "<descriptor>");
+                    }
+
+                    if (!string.IsNullOrEmpty(mappingCmd))
+                    {
+                        ConsoleHelper.WriteLine(mappingCmd, ConsoleColor.Yellow);
+                    }
+                }
+                if (platform == Platform.GitHub)
+                {
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetGitHubTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No GitHub token found", ConsoleColor.Red); return 1; }
+                    var client = new GitHubClient(token);
+                    var repo = _platformDetector.GetRepositoryInfo();
+                    if (repo == null) { ConsoleHelper.WriteLine("X Could not determine repository", ConsoleColor.Red); return 1; }
+                    var perm = await client.GetRepositoryPermissionAsync(repo.Owner!, repo.Repo!, user, verbose);
+                    Console.WriteLine(perm ?? "No permission info available");
+                    return 0;
+                }
+                else if (platform == Platform.AzureDevOps)
+                {
+                    var auth = new AuthenticationService();
+                    var token = await auth.GetAzureDevOpsTokenAsync();
+                    if (string.IsNullOrEmpty(token)) { ConsoleHelper.WriteLine("X No Azure DevOps PAT found", ConsoleColor.Red); return 1; }
+                    var org = _platformDetector.GetOrganization();
+                    if (string.IsNullOrEmpty(org)) { ConsoleHelper.WriteLine("X Could not determine organization", ConsoleColor.Red); return 1; }
+                    var client = new AzureDevOpsClient(token, org);
+                    var perms = await client.GetUserPermissionsAsync(user, verbose);
+                    if (perms == null) { Console.WriteLine("No permission info available"); return 0; }
+                    foreach (var p in perms) Console.WriteLine($"{p.Key}: {p.Value}");
+                    return 0;
+                }
+                else
+                {
+                    ConsoleHelper.WriteLine("X Unsupported platform", ConsoleColor.Red);
+                    return 1;
+                }
+            }
+            catch (Exception ex)
+            {
+                ConsoleHelper.WriteLine($"X Error: {ex.Message}", ConsoleColor.Red);
+                return 1;
+            }
+        }
+    }
+}

--- a/Sdo/Mapping/MappingGenerator.cs
+++ b/Sdo/Mapping/MappingGenerator.cs
@@ -123,6 +123,47 @@ namespace Sdo.Mapping
             return $"az boards query --org {organization} --project \"{project}\" --wiql \"{wiql}\"{topPart}";
         }
 
+        public string RepoPermissionGitHub(string owner, string repo, string user)
+        {
+            if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(repo)) return string.Empty;
+            // Use gh repo view to get collaborators and filter by login with --jq
+            var jq = $".collaborators[] | select(.login==\"{user}\") | .permission";
+            return $"gh repo view -R {owner}/{repo} --json collaborators --jq \"{jq}\"";
+        }
+
+        public string UserPermissionsAzure(string organization, string project, string user)
+        {
+            // Prefer az devops commands where possible. Exact namespace query may require namespace id.
+            // Provide a helpful az devops CLI example that queries security permissions for a subject.
+            return $"az devops security permission list --organization https://dev.azure.com/{organization} --project \"{project}\" --subject \"{user}\"";
+        }
+
+        public string CollaboratorsListGitHub(string owner, string repo, int top)
+        {
+            if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(repo)) return string.Empty;
+            var limit = top > 0 ? top : 100;
+            // Use gh repo view to get collaborators and limit output via --limit is not available for this json output,
+            // so advise piping and jq; show simple gh command to list collaborators
+            // Use the query parameter `per_page` which `gh api` accepts in the endpoint URL.
+            // Alternatively users can use `--paginate` to retrieve all pages.
+            return $"gh api repos/{owner}/{repo}/collaborators?per_page={limit}";
+        }
+
+        public string SearchUsersGitHub(string query, int top)
+        {
+            if (string.IsNullOrEmpty(query)) return string.Empty;
+            var qEscaped = query.Replace("\"", "\\\"");
+            var topPart = top > 0 ? $" --limit {top}" : string.Empty;
+            return $"gh search users \"{qEscaped}\"{topPart}";
+        }
+
+        public string ListUsersAzure(string organization, string project, int top)
+        {
+            var topPart = top > 0 ? $" --top {top}" : string.Empty;
+            // az devops users list requires extension; provide example using az devops user or graph users
+            return $"az devops user list --organization https://dev.azure.com/{organization}{topPart}";
+        }
+
         public string WorkItemShowAzure(string organization, string project, int id)
         {
             if (string.IsNullOrEmpty(organization) || string.IsNullOrEmpty(project)) return string.Empty;

--- a/Sdo/Program.cs
+++ b/Sdo/Program.cs
@@ -35,8 +35,10 @@ namespace Sdo
             var rootCommand = new RootCommand("Simple DevOps Operations CLI tool for Azure DevOps and GitHub");
 
             // Add global options
-            var verboseOption = new Option<bool>("--verbose");
-            verboseOption.Description = "Enable verbose output";
+            var verboseOption = new Option<bool>("--verbose")
+            {
+                Description = "Enable verbose output"
+            };
             rootCommand.Options.Add(verboseOption);
 
             // Add commands
@@ -48,15 +50,12 @@ namespace Sdo
             rootCommand.Subcommands.Add(new Commands.WorkItemCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.UserCommand(verboseOption));
 
-            // TODO: Add subcommands for users
-            // Phase 3.6: User Commands
-
-            // For now, just show a placeholder message
+            // Set a default action for the root command when no subcommand is specified
             rootCommand.SetAction((parseResult) =>
             {
-                Console.WriteLine("SDO C# migration starting point.");
-                Console.WriteLine("Commands will be implemented based on the Python sdo functionality.");
-                return 0;
+                Console.WriteLine("Error: Please specify a command (map, auth, pipeline, pr, repo, wi, user)");
+                Console.WriteLine("Run 'sdo.net --help' for usage information.");
+                return 1;
             });
 
             // Parse and execute

--- a/Sdo/Program.cs
+++ b/Sdo/Program.cs
@@ -46,6 +46,7 @@ namespace Sdo
             rootCommand.Subcommands.Add(new Commands.PullRequestCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.RepositoryCommand(verboseOption));
             rootCommand.Subcommands.Add(new Commands.WorkItemCommand(verboseOption));
+            rootCommand.Subcommands.Add(new Commands.UserCommand(verboseOption));
 
             // TODO: Add subcommands for users
             // Phase 3.6: User Commands

--- a/Sdo/Services/AzureDevOpsClient.cs
+++ b/Sdo/Services/AzureDevOpsClient.cs
@@ -309,6 +309,261 @@ namespace Sdo.Services
         }
 
         /// <summary>
+        /// Lists users in the organization using Graph API (basic listing).
+        /// </summary>
+        public async Task<List<AzureDevOpsUser>?> ListUsersAsync(int top = 100)
+        {
+            try
+            {
+                var perPage = Math.Max(1, Math.Min(1000, top));
+                var url = $"https://vssps.dev.azure.com/{_organization}/_apis/graph/users?api-version=7.1-preview.1&$top={perPage}";
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _lastError = $"List users failed: {response.StatusCode} {response.ReasonPhrase}";
+                    return null;
+                }
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                using var doc = JsonDocument.Parse(content);
+                if (!doc.RootElement.TryGetProperty("value", out var arr)) return new List<AzureDevOpsUser>();
+
+                var list = new List<AzureDevOpsUser>();
+                foreach (var el in arr.EnumerateArray())
+                {
+                    var u = new AzureDevOpsUser();
+                    if (el.TryGetProperty("descriptor", out var desc)) u.Id = desc.GetString();
+                    if (el.TryGetProperty("displayName", out var dn)) u.DisplayName = dn.GetString();
+                    if (el.TryGetProperty("principalName", out var pn)) u.UniqueName = pn.GetString();
+                    if (el.TryGetProperty("mailAddress", out var ma)) u.PreferredEmail = ma.GetString();
+                    list.Add(u);
+                }
+
+                return list;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception listing users: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to find a user by login/display name by scanning graph users.
+        /// </summary>
+        public async Task<AzureDevOpsUser?> GetUserAsync(string? login)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(login)) return await GetUserAsync();
+                var list = await ListUsersAsync(1000);
+                if (list == null || list.Count == 0) return null;
+                var found = list.FirstOrDefault(u => string.Equals(u.UniqueName, login, StringComparison.OrdinalIgnoreCase)
+                                                   || string.Equals(u.DisplayName, login, StringComparison.OrdinalIgnoreCase)
+                                                   || (!string.IsNullOrEmpty(u.PreferredEmail) && string.Equals(u.PreferredEmail, login, StringComparison.OrdinalIgnoreCase)));
+                return found;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception in GetUserAsync(login): {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets permission summary for a user. Complex permissions model — returns null when not implemented.
+        /// </summary>
+        public async Task<Dictionary<string, string>?> GetUserPermissionsAsync(string? user, bool verbose = false)
+        {
+            try
+            {
+                // Resolve descriptor: if input looks like a descriptor (contains a dot prefix), use it.
+                string? descriptor = null;
+
+                if (!string.IsNullOrEmpty(user) && (user.Contains(".") || user.StartsWith("vssgp") || user.StartsWith("svc") || user.StartsWith("msa") || user.Contains("@")))
+                {
+                    // If user looks like an email or descriptor, try to find matching graph entry
+                    var maybe = await GetUserAsync(user);
+                    descriptor = maybe?.Id ?? user;
+                }
+                else
+                {
+                    // Try to find user via ListUsers
+                    var list = await ListUsersAsync(1000);
+                    if (list != null && list.Count > 0)
+                    {
+                        var found = list.FirstOrDefault(u => string.Equals(u.UniqueName, user, StringComparison.OrdinalIgnoreCase)
+                                                          || string.Equals(u.DisplayName, user, StringComparison.OrdinalIgnoreCase)
+                                                          || (!string.IsNullOrEmpty(u.PreferredEmail) && string.Equals(u.PreferredEmail, user, StringComparison.OrdinalIgnoreCase)));
+                        if (found != null) descriptor = found.Id;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(descriptor))
+                {
+                    _lastError = "Could not resolve user descriptor";
+                    return null;
+                }
+
+                // Determine project id (GUID) for token construction
+                string? projectId = null;
+                if (!string.IsNullOrEmpty(_project))
+                {
+                    try
+                    {
+                        var projUrl = $"https://dev.azure.com/{_organization}/_apis/projects/{Uri.EscapeDataString(_project)}?api-version=7.0";
+                        if (verbose) Console.WriteLine($"[AzureDevOps] GET {projUrl}");
+                        var projResp = await _httpClient.GetAsync(projUrl);
+                        if (projResp.IsSuccessStatusCode)
+                        {
+                            var pc = await projResp.Content.ReadAsStringAsync();
+                            if (verbose) Console.WriteLine($"[AzureDevOps] Response {projResp.StatusCode}: {pc}");
+                            using var doc = JsonDocument.Parse(pc);
+                            if (doc.RootElement.TryGetProperty("id", out var idp)) projectId = idp.GetString();
+                        }
+                    }
+                    catch { /* ignore */ }
+                }
+
+                // If still no project id, try list projects and pick first
+                if (string.IsNullOrEmpty(projectId))
+                {
+                    try
+                    {
+                        var listUrl = $"https://dev.azure.com/{_organization}/_apis/projects?api-version=7.0";
+                        if (verbose) Console.WriteLine($"[AzureDevOps] GET {listUrl}");
+                        var listResp = await _httpClient.GetAsync(listUrl);
+                        if (listResp.IsSuccessStatusCode)
+                        {
+                            var lc = await listResp.Content.ReadAsStringAsync();
+                            if (verbose) Console.WriteLine($"[AzureDevOps] Response {listResp.StatusCode}: {lc}");
+                            using var doc = JsonDocument.Parse(lc);
+                            if (doc.RootElement.TryGetProperty("value", out var arr) && arr.GetArrayLength() > 0)
+                            {
+                                var first = arr.EnumerateArray().First();
+                                if (first.TryGetProperty("id", out var idp)) projectId = idp.GetString();
+                            }
+                        }
+                    }
+                    catch { }
+                }
+
+                if (string.IsNullOrEmpty(projectId))
+                {
+                    _lastError = "Could not determine project id for permission token construction";
+                    return null;
+                }
+
+                // Get security namespaces and pick ones matching Git, Build, Project
+                var namespacesUrl = $"https://dev.azure.com/{_organization}/_apis/securitynamespaces?api-version=6.0";
+                if (verbose) Console.WriteLine($"[AzureDevOps] GET {namespacesUrl}");
+                var nsResp = await _httpClient.GetAsync(namespacesUrl);
+                if (!nsResp.IsSuccessStatusCode)
+                {
+                    _lastError = $"Failed to list security namespaces: {nsResp.StatusCode} {nsResp.ReasonPhrase}";
+                    return null;
+                }
+
+                var nsContent = await nsResp.Content.ReadAsStringAsync();
+                if (verbose) Console.WriteLine($"[AzureDevOps] Response {nsResp.StatusCode}: {nsContent}");
+                using var nsDoc = JsonDocument.Parse(nsContent);
+                var nsMap = new Dictionary<string, string>(); // displayName -> namespaceId
+                if (nsDoc.RootElement.TryGetProperty("value", out var nsArr))
+                {
+                    foreach (var el in nsArr.EnumerateArray())
+                    {
+                        var name = el.GetProperty("displayName").GetString() ?? string.Empty;
+                        var id = el.GetProperty("namespaceId").GetString() ?? string.Empty;
+                        nsMap[name] = id;
+                    }
+                }
+
+                // Candidate namespaces by substring
+                var candidates = nsMap.Where(kv => kv.Key.IndexOf("git", StringComparison.OrdinalIgnoreCase) >= 0
+                                                || kv.Key.IndexOf("build", StringComparison.OrdinalIgnoreCase) >= 0
+                                                || kv.Key.IndexOf("project", StringComparison.OrdinalIgnoreCase) >= 0)
+                                      .ToList();
+
+                if (candidates.Count == 0)
+                {
+                    _lastError = "No matching security namespaces found (git/build/project)";
+                    return null;
+                }
+
+                var results = new Dictionary<string, string>();
+
+                // Construct a project-level token used by many namespaces
+                var projectToken = $"vstfs:///Framework/TeamProject/{projectId}";
+
+                foreach (var ns in candidates)
+                {
+                    var nsDisplay = ns.Key;
+                    var nsId = ns.Value;
+
+                    var aclUrl = $"https://dev.azure.com/{_organization}/_apis/accesscontrollists/{nsId}?api-version=6.0";
+                    var payload = new
+                    {
+                        tokens = new[] { projectToken },
+                        descriptors = new[] { descriptor }
+                    };
+
+                    var content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json");
+                    if (verbose) Console.WriteLine($"[AzureDevOps] POST {aclUrl} payload: {JsonSerializer.Serialize(payload)}");
+                    var aclResp = await _httpClient.PostAsync(aclUrl, content);
+                    var aclRaw = await aclResp.Content.ReadAsStringAsync();
+                    if (verbose) Console.WriteLine($"[AzureDevOps] Response {aclResp.StatusCode}: {aclRaw}");
+                    if (!aclResp.IsSuccessStatusCode)
+                    {
+                        results[$"{nsDisplay}:{projectToken}"] = $"Error querying ACL: {aclResp.StatusCode} {aclResp.ReasonPhrase}";
+                        continue;
+                    }
+                    var aclContent = aclRaw;
+                    using var aclDoc = JsonDocument.Parse(aclContent);
+                    // Parse returned access control entries
+                    if (aclDoc.RootElement.TryGetProperty("items", out var items) && items.GetArrayLength() > 0)
+                    {
+                        foreach (var item in items.EnumerateArray())
+                        {
+                            var token = item.GetProperty("token").GetString() ?? projectToken;
+                            if (item.TryGetProperty("accessControlEntries", out var aces))
+                            {
+                                foreach (var ace in aces.EnumerateArray())
+                                {
+                                    if (!ace.TryGetProperty("descriptor", out var d)) continue;
+                                    var aceDesc = d.GetString();
+                                    if (!string.Equals(aceDesc, descriptor, StringComparison.OrdinalIgnoreCase)) continue;
+
+                                    long allow = ace.TryGetProperty("allow", out var a) ? a.GetInt64() : 0;
+                                    long deny = ace.TryGetProperty("deny", out var de) ? de.GetInt64() : 0;
+                                    results[$"{nsDisplay}:{token}"] = $"allow={allow} deny={deny}";
+                                }
+                            }
+                            else
+                            {
+                                results[$"{nsDisplay}:{token}"] = "no ACEs returned";
+                            }
+                        }
+                    }
+                    else
+                    {
+                        results[$"{nsDisplay}:{projectToken}"] = "no ACL items returned";
+                    }
+                }
+
+                return results;
+            }
+            catch (Exception ex)
+            {
+                _lastError = $"Exception querying permissions: {ex.Message}";
+                System.Diagnostics.Debug.WriteLine(_lastError);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets multiple work items in batched API calls (avoiding URL length limits).
         /// Splits large requests into chunks to stay under the HTTP URL length limit.
         /// </summary>

--- a/Sdo/Services/GitHubClient.cs
+++ b/Sdo/Services/GitHubClient.cs
@@ -129,6 +129,144 @@ namespace Sdo.Services
             }
         }
 
+        /// <summary>
+        /// Gets a GitHub user by login.
+        /// </summary>
+        public async Task<GitHubUser?> GetUserAsync(string login)
+        {
+            try
+            {
+                var url = $"https://api.github.com/users/{Uri.EscapeDataString(login)}";
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                    return null;
+
+                var content = await response.Content.ReadAsStringAsync();
+                var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                var user = JsonSerializer.Deserialize<GitHubUser>(content, options);
+                return user;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Lists collaborators for a repository.
+        /// </summary>
+        public async Task<List<GitHubUser>?> ListCollaboratorsAsync(string owner, string repo, int top = 100)
+        {
+            try
+            {
+                var results = new List<GitHubUser>();
+                int page = 1;
+                int perPage = Math.Max(1, Math.Min(100, top));
+
+                while (true)
+                {
+                    var url = $"https://api.github.com/repos/{owner}/{repo}/collaborators?per_page={perPage}&page={page}";
+                    var response = await _httpClient.GetAsync(url);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        return results.Count > 0 ? results : null;
+                    }
+
+                    var content = await response.Content.ReadAsStringAsync();
+                    var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                    var users = JsonSerializer.Deserialize<List<GitHubUser>>(content, options);
+                    if (users == null || users.Count == 0) break;
+
+                    results.AddRange(users);
+                    if (results.Count >= top) break;
+                    if (users.Count < perPage) break;
+                    page++;
+                }
+
+                if (top > 0 && results.Count > top) results = results.Take(top).ToList();
+                return results;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error listing collaborators: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Searches users on GitHub using the search API.
+        /// </summary>
+        public async Task<List<GitHubUser>?> SearchUsersAsync(string query, int perPage = 30)
+        {
+            try
+            {
+                var url = $"https://api.github.com/search/users?q={Uri.EscapeDataString(query)}&per_page={perPage}";
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode) return null;
+
+                var content = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(content);
+                var root = doc.RootElement;
+                if (!root.TryGetProperty("items", out var items)) return null;
+
+                var list = new List<GitHubUser>();
+                foreach (var item in items.EnumerateArray())
+                {
+                    var login = item.GetProperty("login").GetString();
+                    if (!string.IsNullOrEmpty(login))
+                    {
+                        // Try to get fuller profile; if fails, include minimal info
+                        var u = await GetUserAsync(login!);
+                        if (u != null) list.Add(u);
+                        else list.Add(new GitHubUser { Login = login });
+                    }
+                }
+
+                return list;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error searching users: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the repository permission level for a user. If username is null, resolves current user.
+        /// </summary>
+        public async Task<string?> GetRepositoryPermissionAsync(string owner, string repo, string? username, bool verbose = false)
+        {
+            try
+            {
+                string userToQuery = username ?? string.Empty;
+                if (string.IsNullOrEmpty(userToQuery))
+                {
+                    var me = await GetUserAsync();
+                    userToQuery = me?.Login ?? string.Empty;
+                }
+
+                if (string.IsNullOrEmpty(userToQuery)) return null;
+
+                var url = $"https://api.github.com/repos/{owner}/{repo}/collaborators/{Uri.EscapeDataString(userToQuery)}/permission";
+                if (verbose) Console.WriteLine($"[GitHub] GET {url}");
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode) return null;
+                var content = await response.Content.ReadAsStringAsync();
+                if (verbose) Console.WriteLine($"[GitHub] Response {response.StatusCode}: {content}");
+                using var doc = JsonDocument.Parse(content);
+                if (doc.RootElement.TryGetProperty("permission", out var perm))
+                {
+                    return perm.GetString();
+                }
+                return null;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error getting repository permission: {ex.Message}");
+                return null;
+            }
+        }
+
         public async Task<List<GitHubIssue>?> ListIssuesAsync(string owner, string repo, int perPage = 50, string state = "open", int top = 0)
         {
             try

--- a/SdoTests/ProgramTests.cs
+++ b/SdoTests/ProgramTests.cs
@@ -9,13 +9,13 @@ namespace SdoTests;
 public class ProgramTests
 {
     [Fact]
-    public void Main_WithNoArgs_ReturnsZero()
+    public void Main_WithNoArgs_ReturnsNonZero()
     {
-        // Act
+        // Act - No arguments should return error (1) because a command is required
         var result = Program.Main();
 
         // Assert
-        Assert.Equal(0, result);
+        Assert.Equal(1, result);
     }
 
     [Fact]

--- a/SdoTests/UserCommandTests.cs
+++ b/SdoTests/UserCommandTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2020-2026 naz-hage. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.CommandLine;
+using Xunit;
+using Sdo.Commands;
+
+namespace SdoTests;
+
+public class UserCommandTests
+{
+    private readonly Option<bool> _verboseOption;
+
+    public UserCommandTests()
+    {
+        _verboseOption = new Option<bool>("--verbose");
+        _verboseOption.Description = "Enable verbose output";
+    }
+
+    [Fact]
+    public void Constructor_CreatesCommandWithCorrectNameAndDescription()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        Assert.Equal("user", cmd.Name);
+        Assert.Equal("User management commands for GitHub and Azure DevOps", cmd.Description);
+    }
+
+    [Fact]
+    public void Constructor_AddsExpectedSubcommands()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        Assert.NotNull(cmd.Subcommands);
+        Assert.Contains(cmd.Subcommands, s => s.Name == "show");
+        Assert.Contains(cmd.Subcommands, s => s.Name == "list");
+        Assert.Contains(cmd.Subcommands, s => s.Name == "search");
+        Assert.Contains(cmd.Subcommands, s => s.Name == "permissions");
+    }
+
+    [Fact]
+    public void ShowSubcommand_HasLoginOption()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        var show = Assert.Single(cmd.Subcommands, s => s.Name == "show");
+        var opt = Assert.Single(show.Options, o => o.Name == "--login");
+        Assert.Equal("User login or id", opt.Description);
+    }
+
+    [Fact]
+    public void ListSubcommand_HasTopOption()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        var list = Assert.Single(cmd.Subcommands, s => s.Name == "list");
+        var opt = Assert.Single(list.Options, o => o.Name == "--top");
+        Assert.Equal("Limit results", opt.Description);
+    }
+
+    [Fact]
+    public void SearchSubcommand_RequiresQuery()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        var args = new[] { "search" };
+        var result = cmd.Parse(args).Invoke();
+        Assert.NotEqual(0, result);
+    }
+
+    [Fact]
+    public void PermissionsSubcommand_HasUserOption()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        var perms = Assert.Single(cmd.Subcommands, s => s.Name == "permissions");
+        var opt = Assert.Single(perms.Options, o => o.Name == "--user");
+        Assert.Equal("User login or id", opt.Description);
+    }
+
+    [Fact]
+    public void Subcommands_HaveGlobalVerboseOption()
+    {
+        var cmd = new UserCommand(_verboseOption);
+        foreach (var sub in cmd.Subcommands)
+        {
+            Assert.Contains(sub.Options, o => o.Name == "--verbose");
+        }
+    }
+}

--- a/atools/requirements-dev.txt
+++ b/atools/requirements-dev.txt
@@ -1,9 +1,9 @@
-pytest==8.4.2
-pytest-cov==7.0.0
-pytest-mock==3.15.0
-requests==2.32.4
-click==8.1.7
-pyyaml==6.0.2
-black==24.10.0
-flake8==7.1.1
+pytest==9.0.2
+pytest-cov==7.1.0
+pytest-mock==3.15.1
+requests==2.33.1
+click==8.3.2
+PyYAML==6.0.3
+black==26.3.1
+flake8==7.3.0
 mkdocs==1.6.1

--- a/atools/requirements.txt
+++ b/atools/requirements.txt
@@ -1,7 +1,7 @@
 # Python dependencies for SDO package
 # Keep this minimal; requests is optional at runtime but listed here for convenience.
-requests==2.32.4
-click==8.1.7
-pyyaml==6.0.2
+requests==2.33.1
+click==8.3.2
+PyYAML==6.0.3
 colorama==0.4.6
 

--- a/atools/sdo_package/cli.py
+++ b/atools/sdo_package/cli.py
@@ -88,7 +88,7 @@ class ClickArgs:
         return None
 
 
-@click.group(help=CLI_DOCSTRING)
+@click.group(invoke_without_command=True, help=CLI_DOCSTRING)
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed API error information")
 @click.version_option(version=__version__, prog_name="SDO")
 @click.pass_context
@@ -96,6 +96,10 @@ def cli(ctx, verbose):
     # Store global options in context
     ctx.ensure_object(dict)
     ctx.obj["verbose"] = verbose
+    # If no subcommand was provided, print the CLI header and return success
+    if ctx.invoked_subcommand is None:
+        click.echo(CLI_DOCSTRING)
+        return
 
 
 @cli.group()

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 # MkDocs requirements for documentation with Material theme and Mermaid support
 mkdocs==1.6.1
-mkdocs-material==9.5.31
-pymdown-extensions==10.16.1
+mkdocs-material==9.7.4
+pymdown-extensions==10.21.2
 mkdocs-material-extensions==1.3.1

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -99,17 +99,31 @@ Commands:
 
 Show how `sdo.net` commands map to native platform CLIs (`gh` for GitHub, `az` for Azure DevOps).
 
-**Description:**
-Useful for understanding equivalent commands and learning native CLI syntax.
-
 **Usage:**
 ```bash
 sdo.net map                              # Show all mappings
 sdo.net map --platform gh               # GitHub mappings only
-sdo.net map --platform azdo --all       # All Azure DevOps mappings
+sdo.net map --platform azdo             # Azure DevOps mappings only
+sdo.net map --all                       # Show all mappings for both platforms
+sdo.net map --verbose                   # Show with verbose output
 ```
 
-**Verbose Mode:**
+**Help:**
+```
+$ sdo.net map --help
+
+Description:
+  Show command mappings between SDO and native CLI tools
+
+Usage:
+  sdo.net map [options]
+
+Options:
+  --platform <platform>  Platform to show mappings for (gh=github, azdo=azure-devops, leave empty for auto-detect)
+  --all                  Show all mappings for both platforms
+  -?, -h, --help         Show help and usage information
+```
+
 With `--verbose`, displays exact native API commands for copy/paste.
 
 ---
@@ -118,11 +132,35 @@ With `--verbose`, displays exact native API commands for copy/paste.
 
 Validate credentials are configured for your platform.
 
+**Subcommands:**
+- `gh` — Verify GitHub authentication
+- `azdo` — Verify Azure DevOps authentication
+
+**Help:**
+```
+$ sdo.net auth --help
+
+Description:
+  Verify authentication with GitHub or Azure DevOps
+
+Usage:
+  sdo.net auth [command] [options]
+
+Options:
+  --verbose       Enable verbose output
+  -?, -h, --help  Show help and usage information
+
+Commands:
+  gh    Verify GitHub authentication
+  azdo  Verify Azure DevOps authentication
+```
+
 **Usage:**
 ```bash
 sdo.net auth gh                  # Verify GitHub
 sdo.net auth azdo               # Verify Azure DevOps
 sdo.net auth gh --verbose       # Show token source details
+sdo.net auth azdo --verbose     # Show token source details
 ```
 
 **Success Output:**

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -557,15 +557,15 @@ sdo.net wi update --id 170 --state done
 ### Main Help
 
 ```
-$ sdo.net.net --help
+$ sdo.net --help
 
-sdo.net.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
+sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
 
 Description:
   Simple DevOps Operations CLI tool for Azure DevOps and GitHub
 
 Usage:
-  sdo.net.net [command] [options]
+  sdo.net [command] [options]
 
 Options:
   --verbose       Enable verbose output
@@ -579,6 +579,7 @@ Commands:
   pr        Pull request operations
   repo      Repository management commands
   wi        Work item management commands
+  user      User management commands for GitHub and Azure DevOps
 ```
 Passed!  - Failed: 0, Passed: 48, Skipped: 0, Total: 48
 ```

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -1,10 +1,10 @@
-# sdo.exe - Simple DevOps Operations Tool (C# Version)
+# sdo.net - Simple DevOps Operations Tool (C# Version)
 
-This page documents the `sdo.exe` CLI tool - the C# migration of Simple DevOps Operations. Use this page for detailed usage examples, prerequisites, and command reference.
+This page documents the `sdo.net` CLI tool - the C# migration of Simple DevOps Operations. Use this page for detailed usage examples, prerequisites, and command reference.
 
 ## Overview
 
-`sdo.exe` (Simple DevOps Operations) is a C# implementation providing unified operations for work items across Azure DevOps and GitHub platforms. It automatically detects the target platform from Git remote configuration.
+`sdo.net` (Simple DevOps Operations) is a C# implementation providing unified operations for work items across Azure DevOps and GitHub platforms. It automatically detects the target platform from Git remote configuration.
 
 ### Key Features (Phase 3.1 Complete)
 
@@ -31,15 +31,15 @@ View the available commands and options:
 ### Main Help
 
 ```
-$ sdo --help
+$ sdo.net --help
 
-Simple DevOps Operations (SDO) - C# Migration
+Simple DevOps Operations (sdo.net) - C# Migration
 ============================================
 Description:
   Simple DevOps Operations CLI tool for Azure DevOps and GitHub
 
 Usage:
-  sdo [command] [options]
+  sdo.net [command] [options]
 
 Options:
   --verbose       Enable verbose output
@@ -47,7 +47,7 @@ Options:
   --version       Show version information
 
 Commands:
-  map       Show command mappings between SDO and native CLI tools
+  map       Show command mappings between sdo.net and native CLI tools
   auth      Verify authentication with GitHub or Azure DevOps
   wi  Work item management commands
 ```
@@ -55,15 +55,15 @@ Commands:
 ### wi Command Help
 
 ```
-$ sdo wi --help
+$ sdo.net wi --help
 
-Simple DevOps Operations (SDO) - C# Migration
+Simple DevOps Operations (sdo.net) - C# Migration
 ============================================
 Description:
   Work item management commands
 
 Usage:
-  sdo wi [command] [options]
+  sdo.net wi [command] [options]
 
 Options:
   -?, -h, --help  Show help and usage information
@@ -79,15 +79,15 @@ Commands:
 ### Show Subcommand Help
 
 ```
-$ sdo wi show --help
+$ sdo.net wi show --help
 
-Simple DevOps Operations (SDO) - C# Migration
+Simple DevOps Operations (sdo.net) - C# Migration
 ============================================
 Description:
   Display detailed work item information
 
 Usage:
-  sdo wi show [options]
+  sdo.net wi show [options]
 
 Options:
   --id <id>       Work item ID (required)
@@ -99,15 +99,15 @@ Options:
 ### List Subcommand Help
 
 ```
-$ sdo wi list --help
+$ sdo.net wi list --help
 
-Simple DevOps Operations (SDO) - C# Migration
+Simple DevOps Operations (sdo.net) - C# Migration
 ============================================
 Description:
   List work items with optional filtering
 
 Usage:
-  sdo wi list [options]
+  sdo.net wi list [options]
 
 Options:
   --type <type>                Filter by work item type (PBI, Bug, Task, Spike,
@@ -142,9 +142,9 @@ The tool automatically detects the platform from your current Git remote:
 
 ## Installation
 
-Place `sdo.exe` in your PATH or run directly from:
+Place `sdo.net` in your PATH or run directly from:
 ```
-C:\source\ntools\Sdo\bin\Release\sdo.exe
+C:\source\ntools\sdo.net\bin\Release\sdo.net
 ```
 
 Build from source:
@@ -160,8 +160,8 @@ nb build
 Verify your authentication is configured correctly:
 
 ```bash
-sdo auth gh              # Verify GitHub authentication
-sdo auth devops          # Verify Azure DevOps authentication
+sdo.net auth gh              # Verify GitHub authentication
+sdo.net auth devops          # Verify Azure DevOps authentication
 ```
 
 Success output:
@@ -177,22 +177,22 @@ List work items from the current repository (defaults to GitHub). By default, sh
 
 ```bash
 # List active work items (excludes closed/done by default)
-sdo wi list
+sdo.net wi list
 
 # List specific number of items
-sdo wi list --top 20
+sdo.net wi list --top 20
 
 # Show only done items
-sdo wi list --state Done
+sdo.net wi list --state Done
 
 # Show items in a specific state
-sdo wi list --state "In Progress"
+sdo.net wi list --state "In Progress"
 
 # Show all items including done/closed
-sdo wi list --state closed
+sdo.net wi list --state closed
 
 # Verbose output with debugging information
-sdo wi list --verbose
+sdo.net wi list --verbose
 ```
 
 **Default Behavior:**
@@ -210,7 +210,7 @@ sdo wi list --verbose
 ------------------------------------------------------------------------------------------------------------------------
 #      Title                                    State      Labels                         Assignee
 ------------------------------------------------------------------------------------------------------------------------
-#246   Phase 6: Deployment & Transition (CI,... OPEN       backlog, sdo-migration         Unassigned
+#246   Phase 6: Deployment & Transition (CI,... OPEN       backlog, sdo.net-migration         Unassigned
 #245   Phase 5: Testing & Validation (Unit, ... OPEN       backlog, testing               Unassigned
 #243   Phase 3: Command Implementation (Migr... OPEN       enhancement, backlog           Unassigned
 ...
@@ -234,13 +234,13 @@ Create new work items from markdown files:
 
 ```bash
 # Create from markdown file
-sdo wi create --file-path work-item.md
+sdo.net wi create --file-path work-item.md
 
 # Create with dry-run (preview without creating)
-sdo wi create --file-path work-item.md --dry-run
+sdo.net wi create --file-path work-item.md --dry-run
 
 # Verbose output with JSON payload
-sdo wi create --file-path work-item.md --verbose
+sdo.net wi create --file-path work-item.md --verbose
 ```
 
 **Markdown Format:**
@@ -261,17 +261,17 @@ Update work item properties:
 
 ```bash
 # Update state
-sdo wi update --id 243 --state Done
+sdo.net wi update --id 243 --state Done
 
 # Update title
-sdo wi update --id 243 --title "Updated Title"
+sdo.net wi update --id 243 --title "Updated Title"
 
 # Update state with success message showing new state
-sdo wi update --id 166 --state done
+sdo.net wi update --id 166 --state done
 # Output: √ Work item 166 updated successfully to state: Done
 
 # Update with verbose output
-sdo wi update --id 243 --state "In Progress" --verbose
+sdo.net wi update --id 243 --state "In Progress" --verbose
 ```
 
 **Valid States:**
@@ -284,10 +284,10 @@ Add comments to work items:
 
 ```bash
 # Add comment to issue
-sdo wi comment --id 243 --message "This is my comment"
+sdo.net wi comment --id 243 --message "This is my comment"
 
 # Verbose output
-sdo wi comment --id 243 --message "Great work!" --verbose
+sdo.net wi comment --id 243 --message "Great work!" --verbose
 ```
 
 #### Show Work Item Details
@@ -296,13 +296,13 @@ Display full details of a specific work item:
 
 ```bash
 # Show GitHub issue #243
-sdo wi show --id 243
+sdo.net wi show --id 243
 
 # Show with verbose output
-sdo wi show --id 243 --verbose
+sdo.net wi show --id 243 --verbose
 
 # Show with comments (when available)
-sdo wi show --id 243 --comments
+sdo.net wi show --id 243 --comments
 ```
 
 **Output Format:**
@@ -316,8 +316,8 @@ Created:     2026-03-01T22:48:29.0000000Z
 Updated:     2026-03-01T22:48:29.0000000Z
 
 Description:
-Phase 3 focuses on migrating the Python SDO command implementations to the new C# 
-`Sdo` project. This covers pipeline, PR, and user commands and ensures behavior parity with the Python tool.
+Phase 3 focuses on migrating the Python sdo.net command implementations to the new C# 
+`sdo.net` project. This covers pipeline, PR, and user commands and ensures behavior parity with the Python tool.
 
 - [ ] Implement pipeline commands: `create`, `show`, `list`, `update`, `run`, `status`, `logs`, `lastbuild`, `delete`
 - [ ] Implement PR commands: `merge`, `approve`
@@ -339,7 +339,7 @@ URL: https://github.com/naz-hage/ntools/issues/243
 This section documents the primary commands introduced in Phase 1 (foundation), Phase 2 (service/auth), and Phase 4 (advanced features). Commands are read-only where applicable and follow the same patterns used across the CLI.
 
 ### map — Show native CLI mappings
-Description: show how SDO commands map to native platform CLIs (`gh` for GitHub, `az` / `az repos` for Azure DevOps).
+Description: show how sdo.net commands map to native platform CLIs (`gh` for GitHub, `az` / `az repos` for Azure DevOps).
 
 Options:
 - `--platform <gh|azdo>`: restrict to a single platform mapping
@@ -347,9 +347,9 @@ Options:
 
 Examples:
 ```
-sdo map
-sdo map --platform gh
-sdo map --platform azdo --all
+sdo.net map
+sdo.net map --platform gh
+sdo.net map --platform azdo --all
 ```
 
 Behavior: with `--verbose` many commands print the equivalent native command (e.g. `gh api repos/owner/repo/collaborators?per_page=100`) in yellow for easy copy/paste.
@@ -364,8 +364,8 @@ Options:
 
 Examples:
 ```
-sdo auth gh
-sdo auth azdo --verbose
+sdo.net auth gh
+sdo.net auth azdo --verbose
 ```
 
 ### wi — Work item (issue) commands
@@ -382,12 +382,12 @@ Common Options:
 
 Examples:
 ```
-sdo wi list
-sdo wi list --top 20 --state "In Progress"
-sdo wi show --id 243 --comments
-sdo wi create --file-path ./work-item.md --verbose
-sdo wi update --id 243 --state Done
-sdo wi comment --id 243 --message "Looks good to me"
+sdo.net wi list
+sdo.net wi list --top 20 --state "In Progress"
+sdo.net wi show --id 243 --comments
+sdo.net wi create --file-path ./work-item.md --verbose
+sdo.net wi update --id 243 --state Done
+sdo.net wi comment --id 243 --message "Looks good to me"
 ```
 
 Notes:
@@ -404,8 +404,8 @@ Options:
 
 Examples:
 ```
-sdo repo list --top 5
-sdo repo show --name naz-hage/ntools --verbose
+sdo.net repo list --top 5
+sdo.net repo show --name naz-hage/ntools --verbose
 ```
 
 ### pr — Pull request commands
@@ -419,9 +419,9 @@ Options:
 
 Examples:
 ```
-sdo pr list --state open
-sdo pr show --id 12
-sdo pr merge --id 12 --merge-method squash --verbose
+sdo.net pr list --state open
+sdo.net pr show --id 12
+sdo.net pr merge --id 12 --merge-method squash --verbose
 ```
 
 ### pipeline — Pipeline / workflow commands
@@ -435,9 +435,9 @@ Options:
 
 Examples:
 ```
-sdo pipeline list
-sdo pipeline status --id 1234
-sdo pipeline logs --id 1234 --verbose
+sdo.net pipeline list
+sdo.net pipeline status --id 1234
+sdo.net pipeline logs --id 1234 --verbose
 ```
 
 ### user — User and permissions commands
@@ -452,10 +452,10 @@ Options:
 
 Examples:
 ```
-sdo user list --top 50
-sdo user show --login naz-hage --verbose
-sdo user search --query "naz" --top 20
-sdo user permissions --user naz-hage --verbose
+sdo.net user list --top 50
+sdo.net user show --login naz-hage --verbose
+sdo.net user search --query "naz" --top 20
+sdo.net user permissions --user naz-hage --verbose
 ```
 
 Notes:
@@ -486,7 +486,7 @@ To override platform detection (planned):
 **Cause**: Authentication failed or no open issues in repository
 
 **Solution**:
-1. Verify authentication: `sdo auth gh`
+1. Verify authentication: `sdo.net auth gh`
 2. Check repository has issues: `gh issue list --repo owner/repo`
 3. Try with `--state closed` to verify API is working
 4. Use `--verbose` flag to see detailed error messages
@@ -538,18 +538,18 @@ $env:AZURE_DEVOPS_PAT = "your_token"
 **Solution**:
 1. Use one of the supported states: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress`
 2. Check your project workflow: Some Azure DevOps projects may have different state configurations
-3. Verify the exact state name: Use `sdo wi list --state Done` (capital D) instead of lowercase
+3. Verify the exact state name: Use `sdo.net wi list --state Done` (capital D) instead of lowercase
 
 **Examples**:
 ```bash
 # Correct - uses valid state with exact casing
-sdo wi update --id 170 --state Done
+sdo.net wi update --id 170 --state Done
 
 # Correct - alternative form
-sdo wi update --id 170 --state "In Progress"
+sdo.net wi update --id 170 --state "In Progress"
 
 # Also works - case-insensitive input
-sdo wi update --id 170 --state done
+sdo.net wi update --id 170 --state done
 ```
 
 ## Testing
@@ -557,15 +557,15 @@ sdo wi update --id 170 --state done
 ### Main Help
 
 ```
-$ sdo.net --help
+$ sdo.net.net --help
 
-sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
+sdo.net.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
 
 Description:
   Simple DevOps Operations CLI tool for Azure DevOps and GitHub
 
 Usage:
-  sdo.net [command] [options]
+  sdo.net.net [command] [options]
 
 Options:
   --verbose       Enable verbose output
@@ -573,7 +573,7 @@ Options:
   --version       Show version information
 
 Commands:
-  map       Show command mappings between SDO and native CLI tools
+  map       Show command mappings between sdo.net and native CLI tools
   auth      Verify authentication with GitHub or Azure DevOps
   pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
   pr        Pull request operations
@@ -590,15 +590,15 @@ Test with real repositories:
 ```bash
 # Test with ntools repository
 cd C:\source\ntools
-sdo wi list --top 5
-sdo wi show --id 243
-sdo wi create --file-path test.md --dry-run
-sdo wi update --id 243 --state Done
+sdo.net wi list --top 5
+sdo.net wi show --id 243
+sdo.net wi create --file-path test.md --dry-run
+sdo.net wi update --id 243 --state Done
 
 # Test with different repository
 cd Path\To\Your\Repo
-sdo wi list
-sdo wi show --id <issue_number>
+sdo.net wi list
+sdo.net wi show --id <issue_number>
 ```
 
 
@@ -614,15 +614,6 @@ nb UNIT_TEST_WORKITEM_COMMAND              # Run wi command tests
 nb UNIT_TEST_WORKITEM_STATE_TRANSLATOR     # Run state translator tests
 ```
 
-### Source Code
-
-- **Main Command**: [Sdo/Commands/WorkItemCommand.cs](../../Sdo/Commands/WorkItemCommand.cs)
-- **GitHub Client**: [Sdo/Services/GitHubClient.cs](../../Sdo/Services/GitHubClient.cs)
-- **Azure DevOps Client**: [Sdo/Services/AzureDevOpsClient.cs](../../Sdo/Services/AzureDevOpsClient.cs)
-- **State Management**: [Sdo/Models/WorkItemState.cs](../../Sdo/Models/WorkItemState.cs)
-- **Command Tests**: [SdoTests/WorkItemCommandTests.cs](../../SdoTests/WorkItemCommandTests.cs)
-- **State Translator Tests**: [SdoTests/WorkItemStateTranslatorTests.cs](../../SdoTests/WorkItemStateTranslatorTests.cs)
-
 ### Architecture
 
 The C# implementation follows the `System.CommandLine` framework for CLI parsing and includes:
@@ -636,14 +627,3 @@ The C# implementation follows the `System.CommandLine` framework for CLI parsing
 - Markdown parsing for structured work item creation
 - JSON-patch operations for Azure DevOps updates
 
-## Related Documentation
-
-- [sdo Installation Guide](sdo-installation.md) - Python version setup
-- [sdo-migration-plan.md](sdo-migration-plan.md) - Full migration roadmap
-- [NBuild System](../nbuild/README.md) - Build automation tool
-
-## See Also
-
-- GitHub: https://github.com/naz-hage/ntools
-- Azure DevOps: https://dev.azure.com/naz-hage/ntools
-- Issue #243: Phase 3 Command Implementation

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -70,7 +70,7 @@ git remote -v
 ```
 $ sdo.net --help
 
-sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
+sdo.net v1.73.7 - Simple DevOps Operations by naz-hage (2020-2026)
 
 Description:
   Simple DevOps Operations CLI tool for Azure DevOps and GitHub
@@ -84,9 +84,9 @@ Options:
   --version       Show version information
 
 Commands:
-  map       Show command mappings between sdo.net and native CLI tools
+  map       Show command mappings between SDO and native CLI tools
   auth      Verify authentication with GitHub or Azure DevOps
-  pipeline  Pipeline/workflow management commands
+  pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
   pr        Pull request operations
   repo      Repository management commands
   wi        Work item management commands
@@ -193,7 +193,7 @@ Usage:
 
 Commands:
   comment  Add comment to a work item
-  create   Create a new work item from markdown file
+  create   Create a new work item
   list     List work items with optional filtering
   show     Display detailed work item information
   update   Update work item properties
@@ -222,13 +222,13 @@ sdo.net wi list --verbose                         # Show API commands
 - GitHub: `open`, `closed` (auto-translated)
 
 **Options:**
-- `--top <N>` — Maximum results (default: 50)
-- `--state <state>` — Filter by state
-- `--type <type>` — Filter by type (PBI, Bug, Task, Spike, Epic)
-- `--assigned-to <user>` — Filter by assignee
-- `--assigned-to-me` — Your items
-- `--area <path>` — Filter by area path (Azure DevOps)
-- `--iteration <path>` — Filter by iteration (Azure DevOps)
+- `--type <type>` — Filter by work item type (PBI, Bug, Task, Spike, Epic)
+- `--state <state>` — Filter by state (New, Approved, Committed, Done, To Do, In Progress)
+- `--assigned-to <assigned-to>` — Filter by assigned user (email or display name)
+- `--assigned-to-me` — Filter by work items assigned to current user
+- `--area <area>` — Filter by area path (Azure DevOps only). Example: 'Project\Area\SubArea'
+- `--iteration <iteration>` — Filter by iteration (Azure DevOps only). Example: 'Project\Sprint 1'
+- `--top <top>` — Maximum number of items to return (default: 50)
 - `--verbose` — Show mapping and diagnostics
 
 **Output Example:**
@@ -257,8 +257,7 @@ sdo.net wi show --id 243 --verbose      # Show API command
 
 **Options:**
 - `--id <id>` — Work item ID (required)
-- `--comments` — Include comments/discussion
-- `-c` — Short alias for `--comments`
+- `-c, --comments` — Show comments/discussion
 - `--verbose` — Show mapping
 
 #### wi create
@@ -274,9 +273,8 @@ sdo.net wi create --file-path work-item.md --verbose   # Show mapping
 ```
 
 **Options:**
-- `--file-path <path>` — Path to markdown file (required)
-- `-f <path>` — Short alias
-- `--dry-run` — Preview without creating
+- `-f, --file-path <file-path>` — Path to markdown file containing work item details (required)
+- `--dry-run` — Parse and preview work item creation without creating it
 - `--verbose` — Show mapping
 
 **Markdown Format:**
@@ -319,10 +317,10 @@ sdo.net wi update --id 243 --state done                   # Case-insensitive
 
 **Options:**
 - `--id <id>` — Work item ID (required)
-- `--state <state>` — New state
-- `--title <text>` — New title
-- `--assignee <user>` — New assignee
-- `--description <text>` — New description
+- `--title <title>` — Update work item title
+- `--state <state>` — Update work item state
+- `--assignee <assignee>` — Update assigned user
+- `--description <description>` — Update work item description
 - `--verbose` — Show mapping
 
 **Valid States** (case-insensitive):
@@ -340,7 +338,7 @@ sdo.net wi comment --id 243 --message "Looks good!" --verbose
 
 **Options:**
 - `--id <id>` — Work item ID (required)
-- `--message <text>` — Comment text (required)
+- `--message <message>` — Comment message (required)
 - `--verbose` — Show mapping
 
 ---
@@ -367,44 +365,12 @@ Usage:
   sdo.net pr [command] [options]
 
 Commands:
-  create  Create a pull request from markdown file
-  list    List pull requests in the current repository
-  show    Show detailed information about a pull request
-  status  Show status of a pull request
-  update  Update an existing pull request
+  create          Create a pull request from markdown file
+  list            List pull requests in the current repository
+  show <pr-id>    Show detailed information about a pull request
+  status <pr-id>  Show status of a pull request
+  update          Update an existing pull request
 ```
-
-#### pr list
-
-List pull requests with optional filtering.
-
-**Usage:**
-```bash
-sdo.net pr list                         # List active PRs (default)
-sdo.net pr list --status closed         # List closed PRs
-sdo.net pr list --status merged         # List merged PRs
-sdo.net pr list --top 20               # Limit to 20
-sdo.net pr list --verbose              # Show API commands
-```
-
-**Options:**
-- `--status <status>` — Filter by status: `active`, `closed`, `merged` (default: active)
-- `--top <N>` — Maximum results (default: 10)
-- `--verbose` — Show mapping
-
-#### pr show
-
-Display pull request details.
-
-**Usage:**
-```bash
-sdo.net pr show 12                # Show PR #12
-sdo.net pr show 12 --verbose      # Show API command
-```
-
-**Options:**
-- `<pr-id>` — PR ID/number (required)
-- `--verbose` — Show mapping
 
 #### pr create
 
@@ -421,35 +387,43 @@ sdo.net pr create --file pr.md --verbose              # Show mapping
 ```
 
 **Options:**
-- `--file <path>` — Path to markdown file (required)
-- `-f <path>` — Short alias
-- `--work-item <id>` — Work item ID to link to PR
+- `-f, --file <file>` — Path to markdown file (required)
+- `--work-item <work-item>` — Work item ID to link to PR
 - `--draft` — Create as draft pull request
 - `--dry-run` — Preview without creating
 - `--verbose` — Show mapping
 
-**Markdown Format:**
-```markdown
-# PR Title
+#### pr list
 
-This is the pull request description.
+List pull requests with optional filtering.
 
-## Changes
-- Change 1
-- Change 2
+**Usage:**
+```bash
+sdo.net pr list                         # List active PRs (default)
+sdo.net pr list --status closed         # List closed PRs
+sdo.net pr list --status merged         # List merged PRs
+sdo.net pr list --top 20               # Limit to 20
+sdo.net pr list --verbose              # Show API commands
 ```
 
-Optional YAML metadata:
-```markdown
----
-target_branch: main
-source_branch: feature
-reviewers: "user1, user2"
----
+**Options:**
+- `--status <status>` — Filter PRs by status (default: active)
+- `--top <top>` — Maximum number of PRs to show (default: 10)
+- `--verbose` — Show mapping
 
-# Title
-...
+#### pr show
+
+Display pull request details.
+
+**Usage:**
+```bash
+sdo.net pr show 12                # Show PR #12
+sdo.net pr show 12 --verbose      # Show API command
 ```
+
+**Options:**
+- `<pr-id>` — Pull request number/ID (required)
+- `--verbose` — Show mapping
 
 #### pr status
 
@@ -462,7 +436,7 @@ sdo.net pr status 12 --verbose    # Show full details
 ```
 
 **Options:**
-- `<pr-id>` — PR ID/number (required)
+- `<pr-id>` — Pull request number/ID (required)
 - `--verbose` — Show mapping
 
 #### pr update
@@ -478,12 +452,10 @@ sdo.net pr update --pr-id 12 --title "New title" --status merged
 ```
 
 **Options:**
-- `--pr-id <id>` — PR ID to update (required)
-- `--file <path>` — Markdown file with updated details
-- `-f <path>` — Short alias for `--file`
-- `--title <text>` — New title
-- `-t <text>` — Short alias for `--title`
-- `--status <status>` — New status (`active`, `closed`, `merged`)
+- `--pr-id <pr-id>` — PR ID to update (required)
+- `-f, --file <file>` — Markdown file with updated details
+- `-t, --title <title>` — New title
+- `--status <status>` — New status
 - `--verbose` — Show mapping
 
 ---
@@ -509,10 +481,10 @@ Usage:
   sdo.net repo [command] [options]
 
 Commands:
-  create      Create a new repository
-  delete      Delete a repository
-  list        List repositories
-  show        Display repository information from current Git remote
+  create <name>  Create a new repository
+  delete         Delete a repository
+  list           List repositories
+  show           Display repository information from current Git remote
 ```
 
 #### repo list
@@ -522,24 +494,22 @@ List repositories for your organization.
 **Usage:**
 ```bash
 sdo.net repo list                       # List repos
-sdo.net repo list --top 10             # Limit to 10
-sdo.net repo list --org myorg          # Specific organization
-sdo.net repo list --verbose            # Show API commands
+sdo.net repo list --top 10              # Limit to 10
+sdo.net repo list --verbose             # Show API commands
 ```
 
 **Options:**
-- `--top <N>` — Maximum results (default: 50)
-- `--org <org>` — Organization name
+- `--top <top>` — Return top N repositories
 - `--verbose` — Show mapping
 
 #### repo show
 
-Display repository details from current Git remote.
+Display repository information from current Git remote.
 
 **Usage:**
 ```bash
-sdo.net repo show                      # Show current repo
-sdo.net repo show --verbose            # Show API command
+sdo.net repo show                       # Show current repo
+sdo.net repo show --verbose             # Show API command
 ```
 
 **Options:**
@@ -559,7 +529,7 @@ sdo.net repo create myrepo --private --verbose      # With mapping
 
 **Options:**
 - `<name>` — Repository name (required)
-- `--description <text>` — Repository description
+- `--description <description>` — Repository description
 - `--private` — Make repository private
 - `--verbose` — Show mapping
 
@@ -569,9 +539,9 @@ Delete a repository.
 
 **Usage:**
 ```bash
-sdo.net repo delete                    # Delete (with prompt)
-sdo.net repo delete --force            # Delete (no prompt)
-sdo.net repo delete --force --verbose  # Show mapping
+sdo.net repo delete                     # Delete (with prompt)
+sdo.net repo delete --force             # Delete (no prompt)
+sdo.net repo delete --force --verbose   # Show mapping
 ```
 
 **Options:**
@@ -588,33 +558,33 @@ Manage GitHub Actions workflows and Azure Pipelines. **Read-only operations** ar
 - `list` — List pipelines/workflows
 - `show` — Display pipeline details
 - `create` — Create pipeline from YAML file
-- `run` — Trigger pipeline run
-- `status` — Check pipeline status
-- `logs` — View pipeline logs
+- `run` — Execute/trigger a pipeline
+- `status` — Query pipeline build/run status
+- `logs` — Retrieve pipeline execution logs
 - `lastbuild` — Show last build/run
-- `update` — Update pipeline
-- `delete` — Delete pipeline
+- `update` — Update pipeline configuration
+- `delete` — Delete pipeline/workflow
 
 **Help:**
 ```
 $ sdo.net pipeline --help
 
 Description:
-  Pipeline/workflow management commands
+  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
 
 Usage:
   sdo.net pipeline [command] [options]
 
 Commands:
-  create     Create a new pipeline/workflow from YAML definition file
-  delete     Delete a pipeline/workflow
-  lastbuild  Show last build/run for a pipeline
-  list       List pipelines/workflows
-  logs       Display pipeline/workflow logs
-  run        Trigger a pipeline run
-  show       Display pipeline/workflow information
-  status     Check pipeline run status
-  update     Update a pipeline/workflow
+  create <file-path>          Create a new pipeline/workflow from YAML definition file
+  delete <pipeline-id>        Delete a pipeline/workflow
+  lastbuild <pipeline-name>   Show last build/run for a pipeline
+  list                        List pipelines/workflows
+  logs <build-id>             Retrieve pipeline execution logs
+  run <pipeline-name>         Execute/trigger a pipeline
+  show <pipeline-id-or-name>  Display pipeline/workflow details
+  status <build-id>           Query pipeline build/run status
+  update                      Update pipeline configuration
 ```
 
 #### pipeline list
@@ -624,14 +594,14 @@ List pipelines/workflows in repository.
 **Usage:**
 ```bash
 sdo.net pipeline list                   # List pipelines
-sdo.net pipeline list --top 10          # Limit to 10
+sdo.net pipeline list --repo myrepo     # Filter by repository
+sdo.net pipeline list --all             # Show all pipelines in project
 sdo.net pipeline list --verbose         # Show API commands
 ```
 
 **Options:**
-- `--top <N>` — Maximum results (default: 50)
-- `--org <org>` — Organization (Azure DevOps)
-- `--project <project>` — Project name (Azure DevOps)
+- `--repo <repo>` — Filter by repository name
+- `--all` — Show all pipelines in the project
 - `--verbose` — Show mapping
 
 #### pipeline show
@@ -640,12 +610,13 @@ Display pipeline/workflow details.
 
 **Usage:**
 ```bash
-sdo.net pipeline show --id 1234         # Show pipeline
-sdo.net pipeline show --id 1234 --verbose  # Show API command
+sdo.net pipeline show 1234              # Show pipeline by ID
+sdo.net pipeline show myworkflow        # Show pipeline by name
+sdo.net pipeline show --verbose         # Show API command
 ```
 
 **Options:**
-- `--id <id>` — Pipeline or workflow ID (required)
+- `<pipeline-id-or-name>` — Pipeline ID or name (optional; Azure DevOps only)
 - `--verbose` — Show mapping
 
 #### pipeline create
@@ -654,7 +625,7 @@ Create a new pipeline/workflow from YAML file.
 
 **Usage:**
 ```bash
-sdo.net pipeline create --file-path .github/workflows/ci.yml
+sdo.net pipeline create .github/workflows/ci.yml
 sdo.net pipeline create .github/workflows/ci.yml --verbose
 ```
 
@@ -664,44 +635,50 @@ sdo.net pipeline create .github/workflows/ci.yml --verbose
 
 #### pipeline run
 
-Trigger a pipeline run.
+Execute/trigger a pipeline.
 
 **Usage:**
 ```bash
-sdo.net pipeline run --id 1234          # Trigger run
-sdo.net pipeline run --id 1234 --verbose  # Show details
+sdo.net pipeline run myworkflow         # Trigger run
+sdo.net pipeline run myworkflow -b main # Run on specific branch
+sdo.net pipeline run myworkflow --branch develop --verbose
 ```
 
 **Options:**
-- `--id <id>` — Pipeline ID (required)
+- `<pipeline-name>` — Pipeline name (optional, uses current repo if not provided)
+- `-b, --branch <branch>` — Branch to run the pipeline on
 - `--verbose` — Show mapping
 
 #### pipeline status
 
-Check pipeline run status.
+Query pipeline build/run status.
 
 **Usage:**
 ```bash
-sdo.net pipeline status --id 1234       # Check status
-sdo.net pipeline status --id 1234 --verbose  # Show details
+sdo.net pipeline status                 # Show latest build status
+sdo.net pipeline status 1234            # Check specific build
+sdo.net pipeline status 1234 --verbose  # Show details
 ```
 
 **Options:**
-- `--id <id>` — Pipeline or run ID (required)
+- `<build-id>` — Build/run ID (optional, shows latest if not provided)
 - `--verbose` — Show mapping
 
 #### pipeline logs
 
-View pipeline/workflow logs.
+Retrieve pipeline execution logs.
 
 **Usage:**
 ```bash
-sdo.net pipeline logs --id 1234         # Show logs
-sdo.net pipeline logs --id 1234 --verbose  # Show logs with API
+sdo.net pipeline logs                     # Show latest logs
+sdo.net pipeline logs 1234                # Show logs for specific build
+sdo.net pipeline logs --build-id 1234     # Explicit build ID
+sdo.net pipeline logs 1234 --verbose      # Show with details
 ```
 
 **Options:**
-- `--id <id>` — Pipeline or run ID (required)
+- `<build-id>` — Build/run ID (optional, shows latest if not provided)
+- `--build-id <build-id>` — Build/run ID
 - `--verbose` — Show mapping and API commands
 
 #### pipeline lastbuild
@@ -710,7 +687,8 @@ Show last build/run for pipeline.
 
 **Usage:**
 ```bash
-sdo.net pipeline lastbuild myworkflow       # Show last build
+sdo.net pipeline lastbuild              # Last build for current repo
+sdo.net pipeline lastbuild myworkflow   # Last build for specific pipeline
 sdo.net pipeline lastbuild myworkflow --verbose  # Show details
 ```
 
@@ -720,17 +698,20 @@ sdo.net pipeline lastbuild myworkflow --verbose  # Show details
 
 #### pipeline update
 
-Update a pipeline/workflow.
+Update pipeline configuration.
 
 **Usage:**
 ```bash
-sdo.net pipeline update --id 1234 --file-path updated.yml
-sdo.net pipeline update --id 1234 --file-path updated.yml --verbose
+sdo.net pipeline update --file updated.yml
+sdo.net pipeline update --file updated.yml --pipeline myworkflow
+sdo.net pipeline update --file updated.yml --message "Update CI config" --branch main
 ```
 
 **Options:**
-- `--id <id>` — Pipeline ID (required)
-- `--file-path <path>` — Updated YAML file (required)
+- `--file <file>` — Path to pipeline/workflow YAML file to update (required)
+- `--pipeline <pipeline>` — Pipeline/workflow ID or name (optional)
+- `--message <message>` — Commit message to use when updating
+- `--branch <branch>` — Branch to push the update to
 - `--verbose` — Show mapping
 
 #### pipeline delete
@@ -739,12 +720,13 @@ Delete a pipeline/workflow.
 
 **Usage:**
 ```bash
-sdo.net pipeline delete --id 1234       # Delete (with prompt)
-sdo.net pipeline delete --id 1234 --force  # Delete (no prompt)
+sdo.net pipeline delete 1234            # Delete (with prompt)
+sdo.net pipeline delete 1234 --force    # Delete (no prompt)
+sdo.net pipeline delete 1234 --force --verbose
 ```
 
 **Options:**
-- `<pipeline-id>` — Pipeline ID (optional, uses current repo if not provided)
+- `<pipeline-id>` — Pipeline/workflow ID or name (optional, uses current repo if not provided)
 - `--force` — Skip confirmation prompt
 - `--verbose` — Show mapping
 

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -334,6 +334,134 @@ URL: https://github.com/naz-hage/ntools/issues/243
 - `--comments`: Include comments/discussion items
 - `--verbose`: Show detailed diagnostic information
 
+## Command Reference (Phases 1, 2 & 4)
+
+This section documents the primary commands introduced in Phase 1 (foundation), Phase 2 (service/auth), and Phase 4 (advanced features). Commands are read-only where applicable and follow the same patterns used across the CLI.
+
+### map — Show native CLI mappings
+Description: show how SDO commands map to native platform CLIs (`gh` for GitHub, `az` / `az repos` for Azure DevOps).
+
+Options:
+- `--platform <gh|azdo>`: restrict to a single platform mapping
+- `--all` : show all mappings for both platforms
+
+Examples:
+```
+sdo map
+sdo map --platform gh
+sdo map --platform azdo --all
+```
+
+Behavior: with `--verbose` many commands print the equivalent native command (e.g. `gh api repos/owner/repo/collaborators?per_page=100`) in yellow for easy copy/paste.
+
+### auth — Verify authentication
+Description: validate available credentials for the detected platform.
+
+Options:
+- `gh` : verify GitHub auth (checks `GITHUB_TOKEN`, `gh auth`, Windows credential store)
+- `azdo` : verify Azure DevOps PAT (`AZURE_DEVOPS_PAT`)
+- `--verbose` : show token detection details and any scope information
+
+Examples:
+```
+sdo auth gh
+sdo auth azdo --verbose
+```
+
+### wi — Work item (issue) commands
+Description: CRUD and comment operations for GitHub issues and Azure DevOps work items. Options are translated between platforms.
+
+Common Options:
+- `--id <number>` : identifier for show/update/comment
+- `--top <n>` : limit number of results for `list` (default: 50)
+- `--state <state>` : filter or set state (Azure states: `New, Approved, Committed, Done, To Do, In Progress`; GitHub: `open|closed`)
+- `--assigned-to <user>` : filter by assignee (planned)
+- `--file-path <path>` : markdown file for `create`
+- `--comments` : include comments in `show`
+- `--verbose` : show mapping and extra diagnostics
+
+Examples:
+```
+sdo wi list
+sdo wi list --top 20 --state "In Progress"
+sdo wi show --id 243 --comments
+sdo wi create --file-path ./work-item.md --verbose
+sdo wi update --id 243 --state Done
+sdo wi comment --id 243 --message "Looks good to me"
+```
+
+Notes:
+- `create` accepts a markdown document with Title, Description and Acceptance Criteria (see examples earlier in this doc).
+- `update --state` performs platform-aware translation (Azure DevOps -> GitHub open/closed mapping where appropriate).
+
+### repo — Repository commands
+Description: list and inspect repositories for the authenticated user or detected organization.
+
+Options:
+- `--top <n>` : limit results
+- `--org <organization>` : specify organization (Azure/GitHub)
+- `--verbose` : show mapping and API request details
+
+Examples:
+```
+sdo repo list --top 5
+sdo repo show --name naz-hage/ntools --verbose
+```
+
+### pr — Pull request commands
+Description: list, show and operate on pull requests. Merge/approve operations are considered advanced and require write permissions.
+
+Options:
+- `--id <id>` : pull request id/number
+- `--state <open|closed|merged>` : filter PR list
+- `--merge-method <merge|squash|rebase>` : merge strategy (GitHub)
+- `--verbose` : show mapping and API details
+
+Examples:
+```
+sdo pr list --state open
+sdo pr show --id 12
+sdo pr merge --id 12 --merge-method squash --verbose
+```
+
+### pipeline — Pipeline / workflow commands
+Description: manage CI pipelines / workflows. Read-only operations are safe for E2E parity checks; trigger/update operations are advanced.
+
+Options:
+- `--id <id>` : pipeline or run id
+- `--top <n>` : limit list results
+- `--org`, `--project` : Azure DevOps scoping
+- `--verbose` : show equivalent `gh/az` commands and API payloads
+
+Examples:
+```
+sdo pipeline list
+sdo pipeline status --id 1234
+sdo pipeline logs --id 1234 --verbose
+```
+
+### user — User and permissions commands
+Description: list/search users and show permission summaries for a user or identity. Useful for audits and E2E parity checks.
+
+Options:
+- `--login <login>` : GitHub login or Azure identity shorthand
+- `--user <login|descriptor>` : user identifier for permissions queries
+- `--query <term>` : search term for `search`
+- `--top <n>` : limit results
+- `--verbose` : show mapping and the exact API calls performed
+
+Examples:
+```
+sdo user list --top 50
+sdo user show --login naz-hage --verbose
+sdo user search --query "naz" --top 20
+sdo user permissions --user naz-hage --verbose
+```
+
+Notes:
+- Many Phase 4 commands are implemented to match Python behavior and are included where ready; others are planned or gated behind integration tests.
+- Use `--verbose` on most commands to display an equivalent native CLI mapping (e.g., `gh` or `az`), request/response dumps, and extra diagnostics.
+
 ## Platform Detection
 
 The tool automatically detects which platform to use based on your Git remote:
@@ -426,29 +554,32 @@ sdo wi update --id 170 --state done
 
 ## Testing
 
-### Unit Tests
+### Main Help
 
-All commands have comprehensive unit test coverage:
-
-```bash
-# Run all wi command tests
-cd C:\source\ntools
-nb UNIT_TEST_WORKITEM_COMMAND
-
-# Output shows tests for create, update, comment, list, show
-Passed!  - Failed: 0, Passed: 78, Skipped: 0, Total: 78
 ```
+$ sdo.net --help
 
-### State Translator Tests
+sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
 
-Test state handling and translation:
+Description:
+  Simple DevOps Operations CLI tool for Azure DevOps and GitHub
 
-```bash
-# Run state translator tests
-cd C:\source\ntools
-nb UNIT_TEST_WORKITEM_STATE_TRANSLATOR
+Usage:
+  sdo.net [command] [options]
 
-# Output shows 48 tests for parse, GitHub translation, Azure DevOps translation
+Options:
+  --verbose       Enable verbose output
+  -?, -h, --help  Show help and usage information
+  --version       Show version information
+
+Commands:
+  map       Show command mappings between SDO and native CLI tools
+  auth      Verify authentication with GitHub or Azure DevOps
+  pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
+  pr        Pull request operations
+  repo      Repository management commands
+  wi        Work item management commands
+```
 Passed!  - Failed: 0, Passed: 48, Skipped: 0, Total: 48
 ```
 
@@ -470,70 +601,6 @@ sdo wi list
 sdo wi show --id <issue_number>
 ```
 
-## Phase Status
-
-### Phase 3.1 - ✅ Work Item Commands (COMPLETE)
-
-#### Show & List
-- ✅ Implement `wi show` subcommand - Display detailed work item information
-- ✅ Implement `wi list` subcommand - List work items with filtering
-- ✅ Default filtering (excludes done/closed to show active work)
-- ✅ Support GitHub issues with full metadata
-- ✅ Proper date deserialization and formatting
-- ✅ Labels and assignee display
-- ✅ 33 unit tests passing
-- ✅ Real data verified with GitHub API
-- ✅ Clean output formatting matching Python SDO
-
-#### Create, Update, Comment
-- ✅ Implement `wi create` subcommand - Create work items from markdown files
-- ✅ Implement `wi update` subcommand - Update work item properties with state translation
-- ✅ Implement `wi comment` subcommand - Add comments to work items
-- ✅ Markdown parsing (title, description, acceptance criteria)
-- ✅ JSON-patch API integration for Azure DevOps
-- ✅ Platform-aware state translation (New/Approved/Committed/Done/To Do/In Progress)
-- ✅ Dry-run support for preview before creation
-- ✅ Verbose logging and success messages with state acknowledgement
-- ✅ Comprehensive error handling with state guidance
-- ✅ 48 unit tests for WorkItemStateTranslator
-- ✅ GitHub and Azure DevOps API integration
-
-### Phase 3.2 - Pending
-
-- ⏳ Add filtering options (--type, --assigned-to, --assigned-to-me)
-- ⏳ Enhanced query capabilities
-
-### Phase 3.3-3.5 - Planned
-
-- Repository commands (`repo create`, `repo list`, `repo show`, `repo delete`)
-- Pull request commands (`pr merge`, `pr approve`, `pr list`, `pr show`)
-- Pipeline commands (`pipeline create`, `pipeline run`, `pipeline status`, etc.)
-- User/Permission commands (`user show`, `user list`, `user search`, `permissions`)
-
-## Implementation Notes
-
-**Phase 3.1 Show & List (March 11, 2026)**:
-- ✅ **GitHub API Pagination**: Full pagination implemented to fetch all issues across multiple pages
-- ✅ **State Filtering**: Default behavior excludes closed items; `--state closed` retrieves closed issues  
-- ✅ **Result Limiting**: `--top` parameter correctly limits results after filtering
-- ✅ All 33 unit tests passing with pagination
-- ✅ Verified with real data: `wi list` returns all open issues
-
-**Phase 3.1 State Management (March 18, 2026)**:
-- ✅ **Canonical State Definitions**: 6 states from Python SDO (New, Approved, Committed, Done, To Do, In Progress)
-- ✅ **State Translation**: Automatic conversion between Azure DevOps and GitHub states
-- ✅ **WorkItemStateTranslator**: Centralized state handling with 48 unit tests
-- ✅ **Error Handling**: Platform-specific error messages with supported states guidance
-- ✅ **Success Messages**: Update commands show the state being changed to
-- ✅ **Create from Markdown**: Support for file-driven creation with acceptance criteria
-- ✅ **Dry-run Support**: Preview work items before creation
-- ✅ **Comment Support**: Add discussion to work items on both platforms
-
-**Platform State Handling**:
-- **Azure DevOps**: Uses exact state names with proper casing ("To Do", "In Progress")
-- **GitHub**: Translates states to open/closed binary model
-- **Default List Behavior**: Excludes done/closed items to show active work
-- **With --state**: Allows viewing items in any state including done/closed
 
 ## Development
 

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -6,35 +6,48 @@ This page documents the `sdo.net` CLI tool - the C# migration of Simple DevOps O
 
 `sdo.net` (Simple DevOps Operations) is a C# implementation providing unified operations for work items across Azure DevOps and GitHub platforms. It automatically detects the target platform from Git remote configuration.
 
-### Key Features (Phase 3.1 Complete)
+### Key Features
 
 - **Work Item Management**:
-  - `wi show`: Display detailed work item information (GitHub issues or Azure DevOps work items)
-  - `wi list`: List work items with filtering and pagination (excludes done/closed by default)
-  - `wi create`: Create new work items from markdown files with title, description, and acceptance criteria
-  - `wi update`: Update work item properties (title, state, description, assignee) with platform-aware state translation
-  - `wi comment`: Add comments/discussion to work items
-- **Multi-Platform Support**: Seamless operations across Azure DevOps and GitHub
-- **Automatic Platform Detection**: Detects platform from Git remote configuration
-- **State Management**: Canonical work item states (New, Approved, Committed, Done, To Do, In Progress) with automatic platform translation
-- **Clean Output Formatting**: Native table display with emoji headers and proper column alignment
-- **Comprehensive Error Handling**: Platform-specific error messages with state guidance
+  - `wi` commands for listing, showing, creating, updating and commenting on work items (GitHub issues/Azure DevOps work items) with cross-platform state translation
 
-### Planned Features (Phase 3.2+)
+- **Pull Request (PR) Commands**:
+  - `pr` commands for listing, showing, creating and updating pull requests (merge/approve planned as advanced ops)
 
-- Additional commands: `pipeline`, `pr` (pull request), `repo` (repository) management
+- **Pipeline / Workflow Commands**:
+  - `pipeline` commands to list, show, create, run, check status, view logs and manage pipeline definitions
 
-## Help Output
+- **Repository Commands**:
+  - `repo` commands to list, show and manage repositories with consistent cross-platform output
 
-View the available commands and options:
+- **User & Permissions Commands**:
+  - `user` subcommands: `list`, `show`, `search`, `permissions` — useful for audits and parity checks
+
+- **Map / Native CLI Mappings**:
+  - `map` shows how SDO commands map to native platform CLIs (`gh`, `az`), and with `--verbose` prints the exact native API commands (copy/paste ready)
+
+- **Platform Auto-Detection**: Extracts org/project from Git remotes and selects GitHub or Azure DevOps automatically
+
+- **State Management & Translation**:
+  - Canonical work item states: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress` with automatic translation to GitHub `open|closed` where appropriate
+
+- **Performance & API Improvements**:
+  - Pagination and batch API optimizations for GitHub and Azure DevOps (reduced O(n) calls)
+
+- **Testing & CI Targets**:
+  - Comprehensive unit test suites (work item, repo, PR tests) and specific `UNIT_TEST_*` targets for CI and local verification
+
+- **UX & Output**:
+  - Clean, emoji-enhanced table output and concise error messages; verbose mode exposes request/response and mapping information for debugging
+
 
 ### Main Help
 
 ```
 $ sdo.net --help
 
-Simple DevOps Operations (sdo.net) - C# Migration
-============================================
+sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
+
 Description:
   Simple DevOps Operations CLI tool for Azure DevOps and GitHub
 
@@ -49,9 +62,18 @@ Options:
 Commands:
   map       Show command mappings between sdo.net and native CLI tools
   auth      Verify authentication with GitHub or Azure DevOps
-  wi  Work item management commands
+  pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
+  pr        Pull request operations
+  repo      Repository management commands
+  wi        Work item management commands
+  user      User management commands for GitHub and Azure DevOps
 ```
 
+## Help Output
+
+View the available commands and options:
+
+ 
 ### wi Command Help
 
 ```
@@ -334,7 +356,7 @@ URL: https://github.com/naz-hage/ntools/issues/243
 - `--comments`: Include comments/discussion items
 - `--verbose`: Show detailed diagnostic information
 
-## Command Reference (Phases 1, 2 & 4)
+## Command Reference
 
 This section documents the primary commands introduced in Phase 1 (foundation), Phase 2 (service/auth), and Phase 4 (advanced features). Commands are read-only where applicable and follow the same patterns used across the CLI.
 
@@ -554,35 +576,6 @@ sdo.net wi update --id 170 --state done
 
 ## Testing
 
-### Main Help
-
-```
-$ sdo.net --help
-
-sdo.net v1.72.6 - Simple DevOps Operations by naz-hage (2020-2026)
-
-Description:
-  Simple DevOps Operations CLI tool for Azure DevOps and GitHub
-
-Usage:
-  sdo.net [command] [options]
-
-Options:
-  --verbose       Enable verbose output
-  -?, -h, --help  Show help and usage information
-  --version       Show version information
-
-Commands:
-  map       Show command mappings between sdo.net and native CLI tools
-  auth      Verify authentication with GitHub or Azure DevOps
-  pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
-  pr        Pull request operations
-  repo      Repository management commands
-  wi        Work item management commands
-  user      User management commands for GitHub and Azure DevOps
-```
-Passed!  - Failed: 0, Passed: 48, Skipped: 0, Total: 48
-```
 
 ### Manual Testing
 
@@ -614,17 +607,4 @@ nb test                                     # Run all tests
 nb UNIT_TEST_WORKITEM_COMMAND              # Run wi command tests
 nb UNIT_TEST_WORKITEM_STATE_TRANSLATOR     # Run state translator tests
 ```
-
-### Architecture
-
-The C# implementation follows the `System.CommandLine` framework for CLI parsing and includes:
-
-- Automatic platform detection via `PlatformDetector`
-- Async API calls via `GitHubClient` and `AzureDevOpsClient`
-- Centralized state management via `WorkItemStateTranslator` with 6 canonical states
-- Platform-aware state translation (Azure DevOps ↔ GitHub)
-- Comprehensive error handling with platform-specific messages and state guidance
-- Clean separation of concerns: Commands → Services → API Clients
-- Markdown parsing for structured work item creation
-- JSON-patch operations for Azure DevOps updates
 

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -309,12 +309,12 @@ sdo.net wi comment --id 243 --message "Looks good!" --verbose
 
 ### pr — Pull Request Operations
 
-List, show, create, and manage pull requests on GitHub and Azure DevOps.
+List, show, create, and manage pull requests on GitHub and Azure DevOps. `pr create` uses markdown files similar to `wi create`.
 
 **Subcommands:**
 - `list` — List pull requests
 - `show` — Display PR details
-- `create` — Create pull request
+- `create` — Create pull request from markdown file
 - `status` — Check PR status
 - `update` — Update PR properties
 
@@ -329,11 +329,11 @@ Usage:
   sdo.net pr [command] [options]
 
 Commands:
-  create  Create a new pull request
-  list    List pull requests
-  show    Display pull request information
-  status  Check pull request status
-  update  Update pull request properties
+  create  Create a pull request from markdown file
+  list    List pull requests in the current repository
+  show    Show detailed information about a pull request
+  status  Show status of a pull request
+  update  Update an existing pull request
 ```
 
 #### pr list
@@ -342,16 +342,16 @@ List pull requests with optional filtering.
 
 **Usage:**
 ```bash
-sdo.net pr list                         # List open PRs
-sdo.net pr list --state closed         # List closed PRs
-sdo.net pr list --state merged         # List merged PRs
+sdo.net pr list                         # List active PRs (default)
+sdo.net pr list --status closed         # List closed PRs
+sdo.net pr list --status merged         # List merged PRs
 sdo.net pr list --top 20               # Limit to 20
 sdo.net pr list --verbose              # Show API commands
 ```
 
 **Options:**
-- `--state <state>` — Filter: `open`, `closed`, `merged`
-- `--top <N>` — Maximum results
+- `--status <status>` — Filter by status: `active`, `closed`, `merged` (default: active)
+- `--top <N>` — Maximum results (default: 10)
 - `--verbose` — Show mapping
 
 #### pr show
@@ -360,31 +360,58 @@ Display pull request details.
 
 **Usage:**
 ```bash
-sdo.net pr show --id 12                # Show PR #12
-sdo.net pr show --id 12 --verbose      # Show API command
+sdo.net pr show 12                # Show PR #12
+sdo.net pr show 12 --verbose      # Show API command
 ```
 
 **Options:**
-- `--id <id>` — PR ID/number (required)
+- `<pr-id>` — PR ID/number (required)
 - `--verbose` — Show mapping
 
 #### pr create
 
-Create a new pull request.
+Create a new pull request from markdown file.
 
 **Usage:**
 ```bash
-sdo.net pr create --title "Fix bug" --description "Details" --source feature-branch --target main
-sdo.net pr create --title "Feature" --source dev --target main --draft
+sdo.net pr create --file pr.md                        # Create from file
+sdo.net pr create -f pr.md                            # Short option
+sdo.net pr create --file pr.md --work-item 243        # Link to work item
+sdo.net pr create --file pr.md --draft                # Create as draft
+sdo.net pr create --file pr.md --dry-run              # Preview
+sdo.net pr create --file pr.md --verbose              # Show mapping
 ```
 
 **Options:**
-- `--title <text>` — PR title (required)
-- `--description <text>` — PR description
-- `--source <branch>` — Source branch
-- `--target <branch>` — Target branch
-- `--draft` — Create as draft (GitHub)
+- `--file <path>` — Path to markdown file (required)
+- `-f <path>` — Short alias
+- `--work-item <id>` — Work item ID to link to PR
+- `--draft` — Create as draft pull request
+- `--dry-run` — Preview without creating
 - `--verbose` — Show mapping
+
+**Markdown Format:**
+```markdown
+# PR Title
+
+This is the pull request description.
+
+## Changes
+- Change 1
+- Change 2
+```
+
+Optional YAML metadata:
+```markdown
+---
+target_branch: main
+source_branch: feature
+reviewers: "user1, user2"
+---
+
+# Title
+...
+```
 
 #### pr status
 
@@ -392,12 +419,12 @@ Check pull request status.
 
 **Usage:**
 ```bash
-sdo.net pr status --id 12              # Check PR status
-sdo.net pr status --id 12 --verbose    # Show full details
+sdo.net pr status 12              # Check PR status
+sdo.net pr status 12 --verbose    # Show full details
 ```
 
 **Options:**
-- `--id <id>` — PR ID/number (required)
+- `<pr-id>` — PR ID/number (required)
 - `--verbose` — Show mapping
 
 #### pr update
@@ -406,15 +433,19 @@ Update pull request properties.
 
 **Usage:**
 ```bash
-sdo.net pr update --id 12 --title "Updated title"
-sdo.net pr update --id 12 --state closed
+sdo.net pr update --pr-id 12 --title "Updated title"
+sdo.net pr update --pr-id 12 --file updated.md
+sdo.net pr update --pr-id 12 --status closed
+sdo.net pr update --pr-id 12 --title "New title" --status merged
 ```
 
 **Options:**
-- `--id <id>` — PR ID/number (required)
+- `--pr-id <id>` — PR ID to update (required)
+- `--file <path>` — Markdown file with updated details
+- `-f <path>` — Short alias for `--file`
 - `--title <text>` — New title
-- `--description <text>` — New description
-- `--state <state>` — New state (`open`, `closed`)
+- `-t <text>` — Short alias for `--title`
+- `--status <status>` — New status (`active`, `closed`, `merged`)
 - `--verbose` — Show mapping
 
 ---

--- a/docs/atools/sdo-net.md
+++ b/docs/atools/sdo-net.md
@@ -1,47 +1,71 @@
 # sdo.net - Simple DevOps Operations Tool (C# Version)
 
-This page documents the `sdo.net` CLI tool - the C# migration of Simple DevOps Operations. Use this page for detailed usage examples, prerequisites, and command reference.
+Unified CLI for managing work items, pull requests, pipelines, and repositories across **GitHub** and **Azure DevOps**.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Key Features](#key-features)
+- [Main Help](#main-help)
+- [Command Reference](#command-reference)
+  - [map — CLI Mappings](#map--cli-mappings)
+  - [auth — Verify Authentication](#auth--verify-authentication)
+  - [wi — Work Item Management](#wi--work-item-management)
+  - [pr — Pull Request Operations](#pr--pull-request-operations)
+  - [pipeline — Pipeline/Workflow Management](#pipeline--pipelineworkflow-management)
+  - [repo — Repository Management](#repo--repository-management)
+  - [user — User Management](#user--user-management)
+- [Troubleshooting](#troubleshooting)
 
 ## Overview
 
-`sdo.net` (Simple DevOps Operations) is a C# implementation providing unified operations for work items across Azure DevOps and GitHub platforms. It automatically detects the target platform from Git remote configuration.
+`sdo.net` (Simple DevOps Operations) is a C# CLI tool providing unified operations across Azure DevOps and GitHub. It:
+- Automatically detects your platform from Git remote configuration
+- Translates work item states and operations between GitHub and Azure DevOps
+- Maps `sdo.net` commands to native platform CLIs for reference and learning
+- Provides consistent cross-platform tooling for teams
 
-### Key Features
+## Prerequisites
 
-- **Work Item Management**:
-  - `wi` commands for listing, showing, creating, updating and commenting on work items (GitHub issues/Azure DevOps work items) with cross-platform state translation
+### Authentication
 
-- **Pull Request (PR) Commands**:
-  - `pr` commands for listing, showing, creating and updating pull requests (merge/approve planned as advanced ops)
+**GitHub**:
+- Install GitHub CLI: `gh auth login`
+- Or set `GITHUB_TOKEN` environment variable
+- Or store credentials in Windows Credential Manager under `gh:github.com:`
 
-- **Pipeline / Workflow Commands**:
-  - `pipeline` commands to list, show, create, run, check status, view logs and manage pipeline definitions
+**Azure DevOps**:
+- Set `AZURE_DEVOPS_PAT` environment variable (Personal Access Token)
+- Or store credentials in Windows Credential Manager under `GitAzureDevOps`
+- PAT must have scopes: Work Item Read, Code Read
 
-- **Repository Commands**:
-  - `repo` commands to list, show and manage repositories with consistent cross-platform output
+### Git Repository Context
 
-- **User & Permissions Commands**:
-  - `user` subcommands: `list`, `show`, `search`, `permissions` — useful for audits and parity checks
+The tool auto-detects your platform from Git remote:
+- **GitHub**: `https://github.com/owner/repo`
+- **Azure DevOps**: `https://dev.azure.com/org/project/_git/repo`
 
-- **Map / Native CLI Mappings**:
-  - `map` shows how SDO commands map to native platform CLIs (`gh`, `az`), and with `--verbose` prints the exact native API commands (copy/paste ready)
+Verify your remote:
+```bash
+git remote -v
+# origin  https://github.com/naz-hage/ntools (fetch)  -> Uses GitHub
+# origin  https://dev.azure.com/org/project/_git/repo (fetch)  -> Uses Azure DevOps
+```
 
-- **Platform Auto-Detection**: Extracts org/project from Git remotes and selects GitHub or Azure DevOps automatically
+## Key Features
 
-- **State Management & Translation**:
-  - Canonical work item states: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress` with automatic translation to GitHub `open|closed` where appropriate
+- **Work Item Management** — Create, list, show, update work items with cross-platform state translation
+- **Pull Requests** — List, show, create pull requests
+- **Pipelines/Workflows** — Create, list, show, run, view logs for GitHub Actions and Azure Pipelines
+- **Repositories** — List and inspect repositories
+- **Users & Permissions** — List users, check permissions, search
+- **Platform Auto-Detection** — Automatically detects GitHub or Azure DevOps from Git remote
+- **CLI Mapping** — Shows sdo.net command equivalents in native CLIs (`gh`, `az`)
+- **State Translation** — Automatically maps work item states between platforms
+- **Clean Output** — Emoji-enhanced tables and concise error messages
 
-- **Performance & API Improvements**:
-  - Pagination and batch API optimizations for GitHub and Azure DevOps (reduced O(n) calls)
-
-- **Testing & CI Targets**:
-  - Comprehensive unit test suites (work item, repo, PR tests) and specific `UNIT_TEST_*` targets for CI and local verification
-
-- **UX & Output**:
-  - Clean, emoji-enhanced table output and concise error messages; verbose mode exposes request/response and mapping information for debugging
-
-
-### Main Help
+## Main Help
 
 ```
 $ sdo.net --help
@@ -62,33 +86,72 @@ Options:
 Commands:
   map       Show command mappings between sdo.net and native CLI tools
   auth      Verify authentication with GitHub or Azure DevOps
-  pipeline  Pipeline/workflow management commands (create, show, list, run, status, logs, delete, lastbuild, update)
+  pipeline  Pipeline/workflow management commands
   pr        Pull request operations
   repo      Repository management commands
   wi        Work item management commands
   user      User management commands for GitHub and Azure DevOps
 ```
 
-## Help Output
+## Command Reference
 
-View the available commands and options:
+### map — CLI Mappings
 
- 
-### wi Command Help
+Show how `sdo.net` commands map to native platform CLIs (`gh` for GitHub, `az` for Azure DevOps).
 
+**Description:**
+Useful for understanding equivalent commands and learning native CLI syntax.
+
+**Usage:**
+```bash
+sdo.net map                              # Show all mappings
+sdo.net map --platform gh               # GitHub mappings only
+sdo.net map --platform azdo --all       # All Azure DevOps mappings
+```
+
+**Verbose Mode:**
+With `--verbose`, displays exact native API commands for copy/paste.
+
+---
+
+### auth — Verify Authentication
+
+Validate credentials are configured for your platform.
+
+**Usage:**
+```bash
+sdo.net auth gh                  # Verify GitHub
+sdo.net auth azdo               # Verify Azure DevOps
+sdo.net auth gh --verbose       # Show token source details
+```
+
+**Success Output:**
+```
+✓ GitHub authentication successful
+```
+
+---
+
+### wi — Work Item Management
+
+Create, list, show, update work items and add comments. Supports GitHub issues and Azure DevOps work items with automatic state translation.
+
+**Subcommands:**
+- `list` — List work items with filtering
+- `show` — Display work item details
+- `create` — Create new work item from markdown file
+- `update` — Update work item properties
+- `comment` — Add comment to work item
+
+**Help:**
 ```
 $ sdo.net wi --help
 
-Simple DevOps Operations (sdo.net) - C# Migration
-============================================
 Description:
   Work item management commands
 
 Usage:
   sdo.net wi [command] [options]
-
-Options:
-  -?, -h, --help  Show help and usage information
 
 Commands:
   comment  Add comment to a work item
@@ -98,178 +161,91 @@ Commands:
   update   Update work item properties
 ```
 
-### Show Subcommand Help
+#### wi list
 
-```
-$ sdo.net wi show --help
+List work items with optional filtering. By default, shows **active** items (excludes closed/done).
 
-Simple DevOps Operations (sdo.net) - C# Migration
-============================================
-Description:
-  Display detailed work item information
-
-Usage:
-  sdo.net wi show [options]
-
-Options:
-  --id <id>       Work item ID (required)
-  -c, --comments  Show comments/discussion
-  --verbose       Enable verbose output
-  -?, -h, --help  Show help and usage information
-```
-
-### List Subcommand Help
-
-```
-$ sdo.net wi list --help
-
-Simple DevOps Operations (sdo.net) - C# Migration
-============================================
-Description:
-  List work items with optional filtering
-
-Usage:
-  sdo.net wi list [options]
-
-Options:
-  --type <type>                Filter by work item type (PBI, Bug, Task, Spike,
-                               Epic)
-  --state <state>              Filter by state (New, Approved, Committed, Done,
-                               To Do, In Progress)
-  --assigned-to <assigned-to>  Filter by assigned user (email or display name)
-  --assigned-to-me             Filter by work items assigned to current user
-  --top <top>                  Maximum number of items to return (default: 50)
-  --verbose                    Enable verbose output
-  -?, -h, --help               Show help and usage information
-```
-
-## Prerequisites
-
-### Authentication
-
-#### GitHub
-- GitHub CLI (`gh`) must be installed and authenticated: `gh auth login`
-- Alternatively, set `GITHUB_TOKEN` environment variable
-- Or store credentials in Windows Credential Manager under `gh:github.com:` target
-
-#### Azure DevOps
-- Set `AZURE_DEVOPS_PAT` environment variable
-- Or store credentials in Windows Credential Manager under `GitAzureDevOps` target
-
-### Git Repository Context
-
-The tool automatically detects the platform from your current Git remote:
-- **GitHub**: Detected from remotes like `https://github.com/owner/repo`
-- **Azure DevOps**: Detected from remotes like `https://dev.azure.com/org/project/_git/repo`
-
-## Installation
-
-Place `sdo.net` in your PATH or run directly from:
-```
-C:\source\ntools\sdo.net\bin\Release\sdo.net
-```
-
-Build from source:
+**Usage:**
 ```bash
-cd C:\source\ntools
-nb build
+sdo.net wi list                                    # List active items
+sdo.net wi list --top 20                           # Limit to 20 items
+sdo.net wi list --state Done                       # Show Done items
+sdo.net wi list --state "In Progress" --top 10    # Show In Progress, limit 10
+sdo.net wi list --assigned-to user@example.com    # Filter by assignee
+sdo.net wi list --assigned-to-me                  # Your items
+sdo.net wi list --type PBI                         # Filter by type (Azure DevOps)
+sdo.net wi list --area "Project\Area"             # Filter by area (Azure DevOps)
+sdo.net wi list --iteration "Project\Sprint 1"    # Filter by iteration (Azure DevOps)
+sdo.net wi list --verbose                         # Show API commands
 ```
-
-## Usage
-
-### Authentication Verification
-
-Verify your authentication is configured correctly:
-
-```bash
-sdo.net auth gh              # Verify GitHub authentication
-sdo.net auth devops          # Verify Azure DevOps authentication
-```
-
-Success output:
-```
-√ GitHub authentication successful
-```
-
-### Work Item Management
-
-#### List Work Items
-
-List work items from the current repository (defaults to GitHub). By default, shows all work items **EXCEPT closed (GitHub) or done/closed (Azure DevOps)** to display active work-in-progress items.
-
-```bash
-# List active work items (excludes closed/done by default)
-sdo.net wi list
-
-# List specific number of items
-sdo.net wi list --top 20
-
-# Show only done items
-sdo.net wi list --state Done
-
-# Show items in a specific state
-sdo.net wi list --state "In Progress"
-
-# Show all items including done/closed
-sdo.net wi list --state closed
-
-# Verbose output with debugging information
-sdo.net wi list --verbose
-```
-
-**Default Behavior:**
-- **GitHub**: Shows all issues EXCEPT `closed`
-- **Azure DevOps**: Shows all work items EXCEPT `done` or `closed`
 
 **Valid States:**
-- Azure DevOps: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress`
-- GitHub: `open`, `closed` (automatically translated from Azure DevOps states)
+- Azure DevOps: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress` (case-insensitive)
+- GitHub: `open`, `closed` (auto-translated)
 
-**Output Format:**
+**Options:**
+- `--top <N>` — Maximum results (default: 50)
+- `--state <state>` — Filter by state
+- `--type <type>` — Filter by type (PBI, Bug, Task, Spike, Epic)
+- `--assigned-to <user>` — Filter by assignee
+- `--assigned-to-me` — Your items
+- `--area <path>` — Filter by area path (Azure DevOps)
+- `--iteration <path>` — Filter by iteration (Azure DevOps)
+- `--verbose` — Show mapping and diagnostics
 
+**Output Example:**
 ```
-📋 Issues (18 found):
-------------------------------------------------------------------------------------------------------------------------
-#      Title                                    State      Labels                         Assignee
-------------------------------------------------------------------------------------------------------------------------
-#246   Phase 6: Deployment & Transition (CI,... OPEN       backlog, sdo.net-migration         Unassigned
-#245   Phase 5: Testing & Validation (Unit, ... OPEN       backlog, testing               Unassigned
-#243   Phase 3: Command Implementation (Migr... OPEN       enhancement, backlog           Unassigned
-...
-------------------------------------------------------------------------------------------------------------------------
+gh Issues (18 found):
+---
+#      Title                                State      Labels                Assignee
+---
+#246   Phase 6: Deployment & Transition    OPEN       backlog, sdo-net      Unassigned
+#245   Phase 5: Testing & Validation       OPEN       backlog, testing      Unassigned
+---
+Summary:
+  OPEN: 18
+```
 
-📊 Total: 18 issue(s)
+#### wi show
+
+Display full details of a work item.
+
+**Usage:**
+```bash
+sdo.net wi show --id 243                # Show item details
+sdo.net wi show --id 243 --comments     # Include comments
+sdo.net wi show --id 243 --verbose      # Show API command
 ```
 
 **Options:**
+- `--id <id>` — Work item ID (required)
+- `--comments` — Include comments/discussion
+- `-c` — Short alias for `--comments`
+- `--verbose` — Show mapping
 
-- `--top <N>`: Maximum number of items to return (default: 50)
-- `--state <state>`: Filter by specific state (e.g., "open", "closed", "In Progress", "Done"). Omit to show all EXCEPT closed/done
-- `--type <type>`: Filter by type (PBI, Bug, Task, etc.) - planned for Phase 3.2
-- `--assigned-to <user>`: Filter by assignee email or name - planned for Phase 3.2
-- `--assigned-to-me`: Filter items assigned to current user - planned for Phase 3.2
-- `--verbose`: Show detailed diagnostic information
+#### wi create
 
-#### Create Work Item
+Create new work item from markdown file.
 
-Create new work items from markdown files:
-
+**Usage:**
 ```bash
-# Create from markdown file
-sdo.net wi create --file-path work-item.md
-
-# Create with dry-run (preview without creating)
-sdo.net wi create --file-path work-item.md --dry-run
-
-# Verbose output with JSON payload
-sdo.net wi create --file-path work-item.md --verbose
+sdo.net wi create --file-path work-item.md              # Create
+sdo.net wi create -f work-item.md                       # Short option
+sdo.net wi create --file-path work-item.md --dry-run   # Preview
+sdo.net wi create --file-path work-item.md --verbose   # Show mapping
 ```
+
+**Options:**
+- `--file-path <path>` — Path to markdown file (required)
+- `-f <path>` — Short alias
+- `--dry-run` — Preview without creating
+- `--verbose` — Show mapping
 
 **Markdown Format:**
 ```markdown
 # Work Item Title
 
-This is the work item description.
+This is the description.
 
 ## Acceptance Criteria
 - Criterion 1
@@ -277,334 +253,641 @@ This is the work item description.
 - Criterion 3
 ```
 
-#### Update Work Item
+Optional YAML metadata:
+```markdown
+---
+work_item_type: PBI
+assignee: user@example.com
+labels: "feature, backlog"
+target: "github"  # or "azdo"
+---
 
-Update work item properties:
+# Title
+...
+```
 
+#### wi update
+
+Update work item properties.
+
+**Usage:**
 ```bash
-# Update state
-sdo.net wi update --id 243 --state Done
-
-# Update title
-sdo.net wi update --id 243 --title "Updated Title"
-
-# Update state with success message showing new state
-sdo.net wi update --id 166 --state done
-# Output: √ Work item 166 updated successfully to state: Done
-
-# Update with verbose output
-sdo.net wi update --id 243 --state "In Progress" --verbose
-```
-
-**Valid States:**
-- `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress` (case-insensitive)
-- GitHub only supports: `open`, `closed`
-
-#### Add Comment
-
-Add comments to work items:
-
-```bash
-# Add comment to issue
-sdo.net wi comment --id 243 --message "This is my comment"
-
-# Verbose output
-sdo.net wi comment --id 243 --message "Great work!" --verbose
-```
-
-#### Show Work Item Details
-
-Display full details of a specific work item:
-
-```bash
-# Show GitHub issue #243
-sdo.net wi show --id 243
-
-# Show with verbose output
-sdo.net wi show --id 243 --verbose
-
-# Show with comments (when available)
-sdo.net wi show --id 243 --comments
-```
-
-**Output Format:**
-
-```
-Issue #243
-======================================================================
-Title:       Phase 3: Command Implementation (Migrate CLI Commands to C#)
-State:       open
-Created:     2026-03-01T22:48:29.0000000Z
-Updated:     2026-03-01T22:48:29.0000000Z
-
-Description:
-Phase 3 focuses on migrating the Python sdo.net command implementations to the new C# 
-`sdo.net` project. This covers pipeline, PR, and user commands and ensures behavior parity with the Python tool.
-
-- [ ] Implement pipeline commands: `create`, `show`, `list`, `update`, `run`, `status`, `logs`, `lastbuild`, `delete`
-- [ ] Implement PR commands: `merge`, `approve`
-- [ ] Implement user commands: `show`, `list`, `search`, `permissions`
-- [ ] Add command-specific unit tests and integration tests
-- [ ] Ensure command-line option parity with Python implementation
-
-URL: https://github.com/naz-hage/ntools/issues/243
+sdo.net wi update --id 243 --state Done                    # Update state
+sdo.net wi update --id 243 --title "New Title"            # Update title
+sdo.net wi update --id 243 --assignee user@example.com    # Change assignee
+sdo.net wi update --id 243 --state Done --title "Title"   # Multiple fields
+sdo.net wi update --id 243 --state done                   # Case-insensitive
 ```
 
 **Options:**
+- `--id <id>` — Work item ID (required)
+- `--state <state>` — New state
+- `--title <text>` — New title
+- `--assignee <user>` — New assignee
+- `--description <text>` — New description
+- `--verbose` — Show mapping
 
-- `--id <number>`: Work item ID (required)
-- `--comments`: Include comments/discussion items
-- `--verbose`: Show detailed diagnostic information
+**Valid States** (case-insensitive):
+- `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress`
 
-## Command Reference
+#### wi comment
 
-This section documents the primary commands introduced in Phase 1 (foundation), Phase 2 (service/auth), and Phase 4 (advanced features). Commands are read-only where applicable and follow the same patterns used across the CLI.
+Add comment to work item.
 
-### map — Show native CLI mappings
-Description: show how sdo.net commands map to native platform CLIs (`gh` for GitHub, `az` / `az repos` for Azure DevOps).
-
-Options:
-- `--platform <gh|azdo>`: restrict to a single platform mapping
-- `--all` : show all mappings for both platforms
-
-Examples:
-```
-sdo.net map
-sdo.net map --platform gh
-sdo.net map --platform azdo --all
-```
-
-Behavior: with `--verbose` many commands print the equivalent native command (e.g. `gh api repos/owner/repo/collaborators?per_page=100`) in yellow for easy copy/paste.
-
-### auth — Verify authentication
-Description: validate available credentials for the detected platform.
-
-Options:
-- `gh` : verify GitHub auth (checks `GITHUB_TOKEN`, `gh auth`, Windows credential store)
-- `azdo` : verify Azure DevOps PAT (`AZURE_DEVOPS_PAT`)
-- `--verbose` : show token detection details and any scope information
-
-Examples:
-```
-sdo.net auth gh
-sdo.net auth azdo --verbose
-```
-
-### wi — Work item (issue) commands
-Description: CRUD and comment operations for GitHub issues and Azure DevOps work items. Options are translated between platforms.
-
-Common Options:
-- `--id <number>` : identifier for show/update/comment
-- `--top <n>` : limit number of results for `list` (default: 50)
-- `--state <state>` : filter or set state (Azure states: `New, Approved, Committed, Done, To Do, In Progress`; GitHub: `open|closed`)
-- `--assigned-to <user>` : filter by assignee (planned)
-- `--file-path <path>` : markdown file for `create`
-- `--comments` : include comments in `show`
-- `--verbose` : show mapping and extra diagnostics
-
-Examples:
-```
-sdo.net wi list
-sdo.net wi list --top 20 --state "In Progress"
-sdo.net wi show --id 243 --comments
-sdo.net wi create --file-path ./work-item.md --verbose
-sdo.net wi update --id 243 --state Done
-sdo.net wi comment --id 243 --message "Looks good to me"
-```
-
-Notes:
-- `create` accepts a markdown document with Title, Description and Acceptance Criteria (see examples earlier in this doc).
-- `update --state` performs platform-aware translation (Azure DevOps -> GitHub open/closed mapping where appropriate).
-
-### repo — Repository commands
-Description: list and inspect repositories for the authenticated user or detected organization.
-
-Options:
-- `--top <n>` : limit results
-- `--org <organization>` : specify organization (Azure/GitHub)
-- `--verbose` : show mapping and API request details
-
-Examples:
-```
-sdo.net repo list --top 5
-sdo.net repo show --name naz-hage/ntools --verbose
-```
-
-### pr — Pull request commands
-Description: list, show and operate on pull requests. Merge/approve operations are considered advanced and require write permissions.
-
-Options:
-- `--id <id>` : pull request id/number
-- `--state <open|closed|merged>` : filter PR list
-- `--merge-method <merge|squash|rebase>` : merge strategy (GitHub)
-- `--verbose` : show mapping and API details
-
-Examples:
-```
-sdo.net pr list --state open
-sdo.net pr show --id 12
-sdo.net pr merge --id 12 --merge-method squash --verbose
-```
-
-### pipeline — Pipeline / workflow commands
-Description: manage CI pipelines / workflows. Read-only operations are safe for E2E parity checks; trigger/update operations are advanced.
-
-Options:
-- `--id <id>` : pipeline or run id
-- `--top <n>` : limit list results
-- `--org`, `--project` : Azure DevOps scoping
-- `--verbose` : show equivalent `gh/az` commands and API payloads
-
-Examples:
-```
-sdo.net pipeline list
-sdo.net pipeline status --id 1234
-sdo.net pipeline logs --id 1234 --verbose
-```
-
-### user — User and permissions commands
-Description: list/search users and show permission summaries for a user or identity. Useful for audits and E2E parity checks.
-
-Options:
-- `--login <login>` : GitHub login or Azure identity shorthand
-- `--user <login|descriptor>` : user identifier for permissions queries
-- `--query <term>` : search term for `search`
-- `--top <n>` : limit results
-- `--verbose` : show mapping and the exact API calls performed
-
-Examples:
-```
-sdo.net user list --top 50
-sdo.net user show --login naz-hage --verbose
-sdo.net user search --query "naz" --top 20
-sdo.net user permissions --user naz-hage --verbose
-```
-
-Notes:
-- Many Phase 4 commands are implemented to match Python behavior and are included where ready; others are planned or gated behind integration tests.
-- Use `--verbose` on most commands to display an equivalent native CLI mapping (e.g., `gh` or `az`), request/response dumps, and extra diagnostics.
-
-## Platform Detection
-
-The tool automatically detects which platform to use based on your Git remote:
-
+**Usage:**
 ```bash
-# List remotes
-git remote -v
-
-# Output shows platform detection
-# origin  https://github.com/naz-hage/ntools (fetch) -> Uses GitHub
-# origin  https://dev.azure.com/org/project/_git/repo (fetch) -> Uses Azure DevOps
+sdo.net wi comment --id 243 --message "This is my comment"
+sdo.net wi comment --id 243 --message "Looks good!" --verbose
 ```
 
-To override platform detection (planned):
-- `--github`: Force GitHub operations
-- `--devops`: Force Azure DevOps operations
+**Options:**
+- `--id <id>` — Work item ID (required)
+- `--message <text>` — Comment text (required)
+- `--verbose` — Show mapping
+
+---
+
+### pr — Pull Request Operations
+
+List, show, create, and manage pull requests on GitHub and Azure DevOps.
+
+**Subcommands:**
+- `list` — List pull requests
+- `show` — Display PR details
+- `create` — Create pull request
+- `status` — Check PR status
+- `update` — Update PR properties
+
+**Help:**
+```
+$ sdo.net pr --help
+
+Description:
+  Pull request operations
+
+Usage:
+  sdo.net pr [command] [options]
+
+Commands:
+  create  Create a new pull request
+  list    List pull requests
+  show    Display pull request information
+  status  Check pull request status
+  update  Update pull request properties
+```
+
+#### pr list
+
+List pull requests with optional filtering.
+
+**Usage:**
+```bash
+sdo.net pr list                         # List open PRs
+sdo.net pr list --state closed         # List closed PRs
+sdo.net pr list --state merged         # List merged PRs
+sdo.net pr list --top 20               # Limit to 20
+sdo.net pr list --verbose              # Show API commands
+```
+
+**Options:**
+- `--state <state>` — Filter: `open`, `closed`, `merged`
+- `--top <N>` — Maximum results
+- `--verbose` — Show mapping
+
+#### pr show
+
+Display pull request details.
+
+**Usage:**
+```bash
+sdo.net pr show --id 12                # Show PR #12
+sdo.net pr show --id 12 --verbose      # Show API command
+```
+
+**Options:**
+- `--id <id>` — PR ID/number (required)
+- `--verbose` — Show mapping
+
+#### pr create
+
+Create a new pull request.
+
+**Usage:**
+```bash
+sdo.net pr create --title "Fix bug" --description "Details" --source feature-branch --target main
+sdo.net pr create --title "Feature" --source dev --target main --draft
+```
+
+**Options:**
+- `--title <text>` — PR title (required)
+- `--description <text>` — PR description
+- `--source <branch>` — Source branch
+- `--target <branch>` — Target branch
+- `--draft` — Create as draft (GitHub)
+- `--verbose` — Show mapping
+
+#### pr status
+
+Check pull request status.
+
+**Usage:**
+```bash
+sdo.net pr status --id 12              # Check PR status
+sdo.net pr status --id 12 --verbose    # Show full details
+```
+
+**Options:**
+- `--id <id>` — PR ID/number (required)
+- `--verbose` — Show mapping
+
+#### pr update
+
+Update pull request properties.
+
+**Usage:**
+```bash
+sdo.net pr update --id 12 --title "Updated title"
+sdo.net pr update --id 12 --state closed
+```
+
+**Options:**
+- `--id <id>` — PR ID/number (required)
+- `--title <text>` — New title
+- `--description <text>` — New description
+- `--state <state>` — New state (`open`, `closed`)
+- `--verbose` — Show mapping
+
+---
+
+### repo — Repository Management
+
+Create, delete, list, and inspect repositories for your organization.
+
+**Subcommands:**
+- `list` — List repositories
+- `show` — Display repo details
+- `create` — Create new repository
+- `delete` — Delete repository
+
+**Help:**
+```
+$ sdo.net repo --help
+
+Description:
+  Repository management commands
+
+Usage:
+  sdo.net repo [command] [options]
+
+Commands:
+  create      Create a new repository
+  delete      Delete a repository
+  list        List repositories
+  show        Display repository information from current Git remote
+```
+
+#### repo list
+
+List repositories for your organization.
+
+**Usage:**
+```bash
+sdo.net repo list                       # List repos
+sdo.net repo list --top 10             # Limit to 10
+sdo.net repo list --org myorg          # Specific organization
+sdo.net repo list --verbose            # Show API commands
+```
+
+**Options:**
+- `--top <N>` — Maximum results (default: 50)
+- `--org <org>` — Organization name
+- `--verbose` — Show mapping
+
+#### repo show
+
+Display repository details from current Git remote.
+
+**Usage:**
+```bash
+sdo.net repo show                      # Show current repo
+sdo.net repo show --verbose            # Show API command
+```
+
+**Options:**
+- `--verbose` — Show mapping
+
+#### repo create
+
+Create a new repository.
+
+**Usage:**
+```bash
+sdo.net repo create myrepo                          # Create repo
+sdo.net repo create myrepo --description "My repo"  # With description
+sdo.net repo create myrepo --private                # Make private
+sdo.net repo create myrepo --private --verbose      # With mapping
+```
+
+**Options:**
+- `<name>` — Repository name (required)
+- `--description <text>` — Repository description
+- `--private` — Make repository private
+- `--verbose` — Show mapping
+
+#### repo delete
+
+Delete a repository.
+
+**Usage:**
+```bash
+sdo.net repo delete                    # Delete (with prompt)
+sdo.net repo delete --force            # Delete (no prompt)
+sdo.net repo delete --force --verbose  # Show mapping
+```
+
+**Options:**
+- `--force` — Skip confirmation prompt
+- `--verbose` — Show mapping
+
+---
+
+### pipeline — Pipeline/Workflow Management
+
+Manage GitHub Actions workflows and Azure Pipelines. **Read-only operations** are safe; **write operations** require permissions.
+
+**Subcommands:**
+- `list` — List pipelines/workflows
+- `show` — Display pipeline details
+- `create` — Create pipeline from YAML file
+- `run` — Trigger pipeline run
+- `status` — Check pipeline status
+- `logs` — View pipeline logs
+- `lastbuild` — Show last build/run
+- `update` — Update pipeline
+- `delete` — Delete pipeline
+
+**Help:**
+```
+$ sdo.net pipeline --help
+
+Description:
+  Pipeline/workflow management commands
+
+Usage:
+  sdo.net pipeline [command] [options]
+
+Commands:
+  create     Create a new pipeline/workflow from YAML definition file
+  delete     Delete a pipeline/workflow
+  lastbuild  Show last build/run for a pipeline
+  list       List pipelines/workflows
+  logs       Display pipeline/workflow logs
+  run        Trigger a pipeline run
+  show       Display pipeline/workflow information
+  status     Check pipeline run status
+  update     Update a pipeline/workflow
+```
+
+#### pipeline list
+
+List pipelines/workflows in repository.
+
+**Usage:**
+```bash
+sdo.net pipeline list                   # List pipelines
+sdo.net pipeline list --top 10          # Limit to 10
+sdo.net pipeline list --verbose         # Show API commands
+```
+
+**Options:**
+- `--top <N>` — Maximum results (default: 50)
+- `--org <org>` — Organization (Azure DevOps)
+- `--project <project>` — Project name (Azure DevOps)
+- `--verbose` — Show mapping
+
+#### pipeline show
+
+Display pipeline/workflow details.
+
+**Usage:**
+```bash
+sdo.net pipeline show --id 1234         # Show pipeline
+sdo.net pipeline show --id 1234 --verbose  # Show API command
+```
+
+**Options:**
+- `--id <id>` — Pipeline or workflow ID (required)
+- `--verbose` — Show mapping
+
+#### pipeline create
+
+Create a new pipeline/workflow from YAML file.
+
+**Usage:**
+```bash
+sdo.net pipeline create --file-path .github/workflows/ci.yml
+sdo.net pipeline create .github/workflows/ci.yml --verbose
+```
+
+**Options:**
+- `<file-path>` — Path to YAML definition file (required)
+- `--verbose` — Show mapping
+
+#### pipeline run
+
+Trigger a pipeline run.
+
+**Usage:**
+```bash
+sdo.net pipeline run --id 1234          # Trigger run
+sdo.net pipeline run --id 1234 --verbose  # Show details
+```
+
+**Options:**
+- `--id <id>` — Pipeline ID (required)
+- `--verbose` — Show mapping
+
+#### pipeline status
+
+Check pipeline run status.
+
+**Usage:**
+```bash
+sdo.net pipeline status --id 1234       # Check status
+sdo.net pipeline status --id 1234 --verbose  # Show details
+```
+
+**Options:**
+- `--id <id>` — Pipeline or run ID (required)
+- `--verbose` — Show mapping
+
+#### pipeline logs
+
+View pipeline/workflow logs.
+
+**Usage:**
+```bash
+sdo.net pipeline logs --id 1234         # Show logs
+sdo.net pipeline logs --id 1234 --verbose  # Show logs with API
+```
+
+**Options:**
+- `--id <id>` — Pipeline or run ID (required)
+- `--verbose` — Show mapping and API commands
+
+#### pipeline lastbuild
+
+Show last build/run for pipeline.
+
+**Usage:**
+```bash
+sdo.net pipeline lastbuild myworkflow       # Show last build
+sdo.net pipeline lastbuild myworkflow --verbose  # Show details
+```
+
+**Options:**
+- `<pipeline-name>` — Pipeline name (optional, uses current repo if not provided)
+- `--verbose` — Show mapping
+
+#### pipeline update
+
+Update a pipeline/workflow.
+
+**Usage:**
+```bash
+sdo.net pipeline update --id 1234 --file-path updated.yml
+sdo.net pipeline update --id 1234 --file-path updated.yml --verbose
+```
+
+**Options:**
+- `--id <id>` — Pipeline ID (required)
+- `--file-path <path>` — Updated YAML file (required)
+- `--verbose` — Show mapping
+
+#### pipeline delete
+
+Delete a pipeline/workflow.
+
+**Usage:**
+```bash
+sdo.net pipeline delete --id 1234       # Delete (with prompt)
+sdo.net pipeline delete --id 1234 --force  # Delete (no prompt)
+```
+
+**Options:**
+- `<pipeline-id>` — Pipeline ID (optional, uses current repo if not provided)
+- `--force` — Skip confirmation prompt
+- `--verbose` — Show mapping
+
+---
+
+### user — User Management
+
+List users, search, and check permissions.
+
+**Subcommands:**
+- `list` — List users
+- `show` — Display user details
+- `search` — Search users
+- `permissions` — Show user permissions
+
+**Help:**
+```
+$ sdo.net user --help
+
+Description:
+  User management commands
+
+Usage:
+  sdo.net user [command] [options]
+
+Commands:
+  list         List users
+  permissions  Show user permissions
+  search       Search for users
+  show         Display user information
+```
+
+#### user list
+
+List users in organization.
+
+**Usage:**
+```bash
+sdo.net user list                      # List users
+sdo.net user list --top 50             # Limit to 50
+sdo.net user list --verbose            # Show API commands
+```
+
+**Options:**
+- `--top <N>` — Maximum results (default: 50)
+- `--verbose` — Show mapping
+
+#### user show
+
+Display user details.
+
+**Usage:**
+```bash
+sdo.net user show --login naz-hage         # Show GitHub user
+sdo.net user show --login naz-hage --verbose  # Show API command
+```
+
+**Options:**
+- `--login <login>` — GitHub login or Azure identity (required)
+- `--verbose` — Show mapping
+
+#### user search
+
+Search for users.
+
+**Usage:**
+```bash
+sdo.net user search --query "naz"              # Search for users
+sdo.net user search --query "naz" --top 20     # Limit to 20
+sdo.net user search --query "naz" --verbose    # Show API command
+```
+
+**Options:**
+- `--query <term>` — Search term (required)
+- `--top <N>` — Maximum results (default: 50)
+- `--verbose` — Show mapping
+
+#### user permissions
+
+Show user permissions.
+
+**Usage:**
+```bash
+sdo.net user permissions --user naz-hage          # Show permissions
+sdo.net user permissions --user naz-hage --verbose  # Show detailed
+```
+
+**Options:**
+- `--user <id>` — User identifier (required)
+- `--verbose` — Show detailed mapping and API calls
+
+---
 
 ## Troubleshooting
 
-### "No issues found"
-
-**Cause**: Authentication failed or no open issues in repository
-
-**Solution**:
-1. Verify authentication: `sdo.net auth gh`
-2. Check repository has issues: `gh issue list --repo owner/repo`
-3. Try with `--state closed` to verify API is working
-4. Use `--verbose` flag to see detailed error messages
-
-### "Could not determine GitHub repository from Git remote"
-
-**Cause**: Git remote configuration is missing or incorrectly formatted
-
-**Solution**:
-1. Check remotes: `git remote -v`
-2. Ensure remotes are properly configured:
-   ```bash
-   git remote add origin https://github.com/owner/repo
-   # or for Azure DevOps
-   git remote add origin https://dev.azure.com/org/project/_git/repo
-   ```
-
 ### Authentication Errors
 
-**GitHub**:
+**Error:** `No authentication token found. Run 'sdo auth' to setup authentication.`
+
+**Causes:**
+- GitHub: `GITHUB_TOKEN` not set, `gh` not authenticated, or no Windows Credential Manager entry
+- Azure DevOps: `AZURE_DEVOPS_PAT` not set or credentials missing
+
+**Solution:**
+
+GitHub:
 ```bash
-# Verify gh CLI is installed and authenticated
+# Verify GitHub CLI is installed and authenticated
 gh auth status
 
 # Re-authenticate if needed
 gh auth login
 
-# Set token via environment variable
-$env:GITHUB_TOKEN = "your_token"
+# Or set token explicitly
+$env:GITHUB_TOKEN = "your_github_token"
 ```
 
-**Azure DevOps**:
+Azure DevOps:
 ```bash
 # Set personal access token
-$env:AZURE_DEVOPS_PAT = "your_token"
+$env:AZURE_DEVOPS_PAT = "your_azure_pat"
+```
+
+### Platform Detection Errors
+
+**Error:** `Could not determine GitHub repository from Git remote`
+
+**Causes:**
+- Git remote not configured
+- Remote URL doesn't match GitHub or Azure DevOps patterns
+
+**Solution:**
+```bash
+# Check remote configuration
+git remote -v
+
+# Add missing remote
+git remote add origin https://github.com/owner/repo
+# or
+git remote add origin https://dev.azure.com/org/project/_git/repo
 ```
 
 ### State Validation Errors
 
-**Update Fails with State Not Supported**:
+**Error:** `Failed to update work item. Supported states: New, Approved, Committed, Done, To Do, In Progress`
 
-```
-✗ Failed to update work item 158
-  Supported states: New, Approved, Committed, Done, To Do, In Progress
-```
+**Causes:**
+- Invalid state name (typo or casing)
+- Project has custom state configuration
 
-**Cause**: The state provided is not valid for your Azure DevOps project configuration
-
-**Solution**:
-1. Use one of the supported states: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress`
-2. Check your project workflow: Some Azure DevOps projects may have different state configurations
-3. Verify the exact state name: Use `sdo.net wi list --state Done` (capital D) instead of lowercase
-
-**Examples**:
+**Solution:**
 ```bash
-# Correct - uses valid state with exact casing
-sdo.net wi update --id 170 --state Done
-
-# Correct - alternative form
-sdo.net wi update --id 170 --state "In Progress"
-
-# Also works - case-insensitive input
-sdo.net wi update --id 170 --state done
+# Use valid state with exact casing (or lowercase)
+sdo.net wi update --id 170 --state Done          # Correct
+sdo.net wi update --id 170 --state "In Progress"  # Correct
+sdo.net wi update --id 170 --state done           # Also works (case-insensitive)
 ```
 
-## Testing
+Valid states:
+- Azure DevOps: `New`, `Approved`, `Committed`, `Done`, `To Do`, `In Progress`
+- GitHub: `open`, `closed` (auto-translated)
 
+### Azure DevOps Permissions Errors
 
-### Manual Testing
+**Error:** `Unauthorized. Insufficient permissions.`
 
-Test with real repositories:
+**Causes:**
+- PAT token doesn't have required scopes
+- Work items feature disabled in project
+
+**Solution:**
+
+Ensure PAT has these scopes:
+- Work Item > Read
+- Code > Read
+
+For write operations:
+- Work Item > Write
+- Code > Write
 
 ```bash
-# Test with ntools repository
-cd C:\source\ntools
-sdo.net wi list --top 5
+# Create new PAT with required scopes
+# https://dev.azure.com/org/_usersSettings/tokens
+```
+
+### Common Option Mistakes
+
+**Using invalid option names:**
+```bash
+# ❌ Wrong
+sdo.net wi list --assigned-to-me-filter
+
+# ✓ Correct
+sdo.net wi list --assigned-to-me
+```
+
+**Forgetting required flags:**
+```bash
+# ❌ Missing --id for show
+sdo.net wi show
+
+# ✓ Correct
 sdo.net wi show --id 243
-sdo.net wi create --file-path test.md --dry-run
-sdo.net wi update --id 243 --state Done
-
-# Test with different repository
-cd Path\To\Your\Repo
-sdo.net wi list
-sdo.net wi show --id <issue_number>
 ```
 
-
-## Development
-
-### Building from Source
-
+**Mixing GitHub and Azure DevOps states:**
 ```bash
-cd C:\source\ntools
-nb build                                    # Build solution
-nb test                                     # Run all tests
-nb UNIT_TEST_WORKITEM_COMMAND              # Run wi command tests
-nb UNIT_TEST_WORKITEM_STATE_TRANSLATOR     # Run state translator tests
+# ❌ GitHub state on Azure DevOps repo
+git remote set-url origin https://dev.azure.com/org/project/_git/repo
+sdo.net wi update --id 243 --state closed  # Won't work
+
+# ✓ Correct
+sdo.net wi update --id 243 --state Done
 ```
 

--- a/e2e-tests.targets
+++ b/e2e-tests.targets
@@ -132,6 +132,61 @@
 		<Message Text="Test output log: $(E2ELogFile)" Importance="normal" />
 	</Target>
 
+	<!-- Run sdo read-only parity tests (Python + C# for GitHub and ConsoleApp1) -->
+	<Target Name="RUN_SDO_READONLY_TEST" DependsOnTargets="COPY_SDO_EXECUTABLE">
+		<Message Text="Running sdo read-only parity tests..." Importance="high" />
+		<!-- GitHub - Python: user list -->
+		<Exec Command="sdo user list" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<!-- GitHub - C#: user list -->
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe user list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+		
+		<!-- GitHub - Python: repo list -->
+		<Exec Command="sdo repo list --top 5" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<!-- GitHub - C#: repo list -->
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe repo list --top 5" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+		
+		<!-- GitHub - Python: workitem list -->
+		<Exec Command="sdo workitem list" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<!-- GitHub - C#: wi list -->
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+		
+		<!-- GitHub - Python: pr list -->
+		<Exec Command="sdo pr ls" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<!-- GitHub - C#: pr list -->
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+		
+		<!-- GitHub - Python: pipeline list -->
+		<Exec Command="sdo pipeline ls" WorkingDirectory="$(SolutionDir)" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<!-- GitHub - C#: pipeline list -->
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline list" WorkingDirectory="$(SolutionDir)" ContinueOnError="true" />
+		
+		<!-- Azure (ConsoleApp1) - Python & C# (same commands in Azure context) -->
+		<Exec Command="sdo user list" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe user list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<Exec Command="sdo repo list --top 5" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe repo list --top 5" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<Exec Command="sdo workitem list" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe wi list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<Exec Command="sdo pr ls" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pr list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<Exec Command="sdo pipeline ls" WorkingDirectory="C:\source\ConsoleApp1" EnvironmentVariables="PYTHONIOENCODING=UTF-8" ContinueOnError="true" />
+		<Exec Command="$(SolutionDir)\Sdo\bin\Debug\sdo.net.exe pipeline list" WorkingDirectory="C:\source\ConsoleApp1" ContinueOnError="true" />
+		
+		<Message Text="✓ sdo read-only parity tests completed" Importance="high" />
+	</Target>
+
+	<!-- E2E ReadOnly target - runs sdo read-only parity checks -->
+	<Target Name="E2E_READONLY" DependsOnTargets="ARTIFACTS;DELETE_E2E_LOG;RUN_SDO_READONLY_TEST">
+		<Message Text="======================================" Importance="high" />
+		<Message Text="✓ sdo read-only parity tests completed successfully" Importance="high" />
+		<Message Text="======================================" Importance="high" />
+		<Message Text="Test output log: $(E2ELogFile)" Importance="normal" />
+	</Target>
+
 	<!-- verify-cli-parity moved from nbuild.targets - compares CLI outputs and pipeline commands -->
 	<Target Name="verify-cli-parity" DependsOnTargets="COPY_SDO_EXECUTABLE">
 		<Message Text="========================================" Importance="high" />

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,6 @@ plugins:
   - search
 
 markdown_extensions:
-  - pymdownx.highlight
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Build System Features:
     - Code Coverage: ntools/code-coverage.md
     - MSBuild Targets: ntools/nbuild-targets.md
+  - TODO: todo.md
   - atools:
     - Overview: atools/index.md
     - List of tools:
@@ -68,3 +69,10 @@ nav:
       - Install NTools: atools/install-ntools.md
     - DevOps Tools Suite Architecture: devops-tools-suite-architecture.md
     - AzDO payloads: atools/azdo_payloads.md
+    - Examples:
+      - AzDO Bug Example: atools/issue-azdo-bug-example.md
+      - AzDO Epic Example: atools/issue-azdo-epic-example.md
+      - AzDO PBI Example: atools/issue-azdo-pbi-example.md
+      - AzDO Task Example: atools/issue-azdo-task-example.md
+      - GitHub Issue Example: atools/issue-gh-example.md
+  - SDO.NET: atools/sdo-net.md


### PR DESCRIPTION
## Description
- Adds `user` subcommands: `list`, `show`, `search`, and `permissions`.
- Prints equivalent native CLI mappings when `--verbose` is used (for `gh`/`az` parity).
- Adds verbose logging hooks in `GitHubClient` and `AzureDevOpsClient`.
- Expands documentation and adds a read-only E2E parity target.

## Business Value
Provides diagnostic parity and read-only audit commands that help operators migrate workflows and verify permissions across GitHub and Azure DevOps without performing destructive actions.

## Key Changes
- `Sdo/Commands/UserCommand.cs`: new `user` subcommands and handlers.
- `Sdo/Mapping/MappingGenerator.cs`: corrected GitHub collaborators mapping.
- `Sdo/Services/GitHubClient.cs` and `Sdo/Services/AzureDevOpsClient.cs`: verbose logging support.
- `SdoTests/UserCommandTests.cs`: rewritten tests stabilizing option/subcommand assertions.
- `e2e-tests.targets`: added `E2E_READONLY` parity target.
- `docs/atools/sdo-net.md`: expanded Command Reference and examples.

## Testing
Describe how these changes have been tested:
- Unit tests: rewritten `UserCommand` tests in `SdoTests` (run locally via `dotnet test`).
- Manual testing: exercised `sdo user list/show/search/permissions --verbose` locally to confirm mapping output.
- E2E: added read-only parity target (requires Python `sdo`, `gh`/`az` auth) — run via nb.exe.

## Validation Steps
Steps to validate the changes locally:
1. Run unit tests:

```powershell
nb test
```

2. Quick manual checks:

```powershell
sdo.net user list --top 10 --verbose
sdo.net user show --login <user> --verbose
```

3. Run the read-only E2E parity target (optional, requires environment credentials):

```powershell
nb E2E_READONLY
```

## Breaking Changes
None expected — changes are read-only diagnostics, mapping fixes, and tests.